### PR TITLE
feat: FrequencyService（頻度判定ロジック）#3

### DIFF
--- a/src/domain/services/__tests__/frequencyService.test.ts
+++ b/src/domain/services/__tests__/frequencyService.test.ts
@@ -1,0 +1,240 @@
+import { isDueToday, getWeeklyProgress } from '../frequencyService';
+import type { Habit, Completion } from '../../models';
+
+const BASE_HABIT: Habit = {
+  id: 'habit-1',
+  name: 'Test Habit',
+  frequency: { type: 'daily' },
+  color: '#FF0000',
+  createdAt: '2026-01-01T00:00:00Z',
+  archivedAt: null,
+};
+
+function makeHabit(overrides: Partial<Habit>): Habit {
+  return { ...BASE_HABIT, ...overrides };
+}
+
+function makeCompletion(habitId: string, completedDate: string): Completion {
+  return {
+    id: `completion-${completedDate}`,
+    habitId,
+    completedDate,
+    createdAt: `${completedDate}T12:00:00Z`,
+  };
+}
+
+describe('isDueToday', () => {
+  describe('daily frequency', () => {
+    const habit = makeHabit({ frequency: { type: 'daily' } });
+
+    it('returns true for any weekday', () => {
+      // Monday
+      expect(isDueToday(habit, new Date('2026-03-09'))).toBe(true);
+    });
+
+    it('returns true for any weekend', () => {
+      // Saturday
+      expect(isDueToday(habit, new Date('2026-03-14'))).toBe(true);
+      // Sunday
+      expect(isDueToday(habit, new Date('2026-03-15'))).toBe(true);
+    });
+  });
+
+  describe('weekly_days frequency', () => {
+    // Monday(1), Wednesday(3), Friday(5)
+    const habit = makeHabit({
+      frequency: { type: 'weekly_days', days: [1, 3, 5] },
+    });
+
+    it('returns true when today is one of the specified days', () => {
+      // 2026-03-09 is Monday (day 1)
+      expect(isDueToday(habit, new Date('2026-03-09'))).toBe(true);
+      // 2026-03-11 is Wednesday (day 3)
+      expect(isDueToday(habit, new Date('2026-03-11'))).toBe(true);
+      // 2026-03-13 is Friday (day 5)
+      expect(isDueToday(habit, new Date('2026-03-13'))).toBe(true);
+    });
+
+    it('returns false when today is not one of the specified days', () => {
+      // 2026-03-10 is Tuesday (day 2)
+      expect(isDueToday(habit, new Date('2026-03-10'))).toBe(false);
+      // 2026-03-12 is Thursday (day 4)
+      expect(isDueToday(habit, new Date('2026-03-12'))).toBe(false);
+      // 2026-03-14 is Saturday (day 6)
+      expect(isDueToday(habit, new Date('2026-03-14'))).toBe(false);
+      // 2026-03-15 is Sunday (day 0)
+      expect(isDueToday(habit, new Date('2026-03-15'))).toBe(false);
+    });
+
+    it('handles Sunday (day 0) as a specified day', () => {
+      const sundayHabit = makeHabit({
+        frequency: { type: 'weekly_days', days: [0] },
+      });
+      // 2026-03-15 is Sunday
+      expect(isDueToday(sundayHabit, new Date('2026-03-15'))).toBe(true);
+      // 2026-03-09 is Monday
+      expect(isDueToday(sundayHabit, new Date('2026-03-09'))).toBe(false);
+    });
+
+    it('handles all days specified', () => {
+      const everydayHabit = makeHabit({
+        frequency: { type: 'weekly_days', days: [0, 1, 2, 3, 4, 5, 6] },
+      });
+      expect(isDueToday(everydayHabit, new Date('2026-03-09'))).toBe(true);
+      expect(isDueToday(everydayHabit, new Date('2026-03-15'))).toBe(true);
+    });
+
+    it('handles single day specified', () => {
+      const wednesdayOnly = makeHabit({
+        frequency: { type: 'weekly_days', days: [3] },
+      });
+      expect(isDueToday(wednesdayOnly, new Date('2026-03-11'))).toBe(true);
+      expect(isDueToday(wednesdayOnly, new Date('2026-03-10'))).toBe(false);
+    });
+  });
+
+  describe('weekly_count frequency', () => {
+    const habit = makeHabit({
+      frequency: { type: 'weekly_count', count: 3 },
+    });
+
+    it('returns true for any day (user can do it any day)', () => {
+      expect(isDueToday(habit, new Date('2026-03-09'))).toBe(true);
+      expect(isDueToday(habit, new Date('2026-03-14'))).toBe(true);
+      expect(isDueToday(habit, new Date('2026-03-15'))).toBe(true);
+    });
+  });
+});
+
+describe('getWeeklyProgress', () => {
+  describe('weekly_count frequency', () => {
+    const habit = makeHabit({
+      frequency: { type: 'weekly_count', count: 3 },
+    });
+
+    it('returns done count and target for completions within the week', () => {
+      // Week starting Monday 2026-03-09
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-09'),
+        makeCompletion('habit-1', '2026-03-11'),
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 2,
+        target: 3,
+      });
+    });
+
+    it('returns done=0 when no completions exist', () => {
+      const weekStart = new Date('2026-03-09');
+      expect(getWeeklyProgress(habit, [], weekStart)).toEqual({
+        done: 0,
+        target: 3,
+      });
+    });
+
+    it('excludes completions outside the week', () => {
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-08'), // before week
+        makeCompletion('habit-1', '2026-03-09'), // in week
+        makeCompletion('habit-1', '2026-03-15'), // end of week (Sunday)
+        makeCompletion('habit-1', '2026-03-16'), // after week
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 2,
+        target: 3,
+      });
+    });
+
+    it('counts all 7 days when all are completed', () => {
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-09'),
+        makeCompletion('habit-1', '2026-03-10'),
+        makeCompletion('habit-1', '2026-03-11'),
+        makeCompletion('habit-1', '2026-03-12'),
+        makeCompletion('habit-1', '2026-03-13'),
+        makeCompletion('habit-1', '2026-03-14'),
+        makeCompletion('habit-1', '2026-03-15'),
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 7,
+        target: 3,
+      });
+    });
+  });
+
+  describe('daily frequency', () => {
+    const habit = makeHabit({ frequency: { type: 'daily' } });
+
+    it('returns target=7 for daily habits', () => {
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-09'),
+        makeCompletion('habit-1', '2026-03-10'),
+        makeCompletion('habit-1', '2026-03-11'),
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 3,
+        target: 7,
+      });
+    });
+  });
+
+  describe('weekly_days frequency', () => {
+    const habit = makeHabit({
+      frequency: { type: 'weekly_days', days: [1, 3, 5] },
+    });
+
+    it('returns target equal to number of specified days', () => {
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-09'), // Monday
+        makeCompletion('habit-1', '2026-03-11'), // Wednesday
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 2,
+        target: 3,
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    const habit = makeHabit({
+      frequency: { type: 'weekly_count', count: 5 },
+    });
+
+    it('handles empty completions array', () => {
+      const weekStart = new Date('2026-03-09');
+      expect(getWeeklyProgress(habit, [], weekStart)).toEqual({
+        done: 0,
+        target: 5,
+      });
+    });
+
+    it('only counts completions for the given habit', () => {
+      const weekStart = new Date('2026-03-09');
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-09'),
+        makeCompletion('other-habit', '2026-03-10'),
+        makeCompletion('habit-1', '2026-03-11'),
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 2,
+        target: 5,
+      });
+    });
+
+    it('handles week boundary precisely (Monday to Sunday)', () => {
+      const weekStart = new Date('2026-03-09'); // Monday
+      const completions: readonly Completion[] = [
+        makeCompletion('habit-1', '2026-03-15'), // Sunday (last day of week)
+      ];
+      expect(getWeeklyProgress(habit, completions, weekStart)).toEqual({
+        done: 1,
+        target: 5,
+      });
+    });
+  });
+});

--- a/src/domain/services/frequencyService.ts
+++ b/src/domain/services/frequencyService.ts
@@ -1,0 +1,89 @@
+import type { Habit, Completion } from '../models';
+
+const DAYS_IN_WEEK = 7;
+
+/**
+ * Determines whether a habit is due on the given date based on its frequency.
+ *
+ * - daily: always true
+ * - weekly_days: true if the date's day of week is in the specified days
+ * - weekly_count: always true (the user can complete it on any day)
+ */
+export function isDueToday(habit: Habit, date: Date): boolean {
+  const { frequency } = habit;
+
+  switch (frequency.type) {
+    case 'daily':
+      return true;
+    case 'weekly_days':
+      return frequency.days.includes(date.getDay());
+    case 'weekly_count':
+      return true;
+  }
+}
+
+/**
+ * Represents the weekly progress for a habit.
+ */
+export type WeeklyProgress = {
+  readonly done: number;
+  readonly target: number;
+};
+
+/**
+ * Calculates how many times a habit was completed during a given week
+ * and what the target count should be.
+ *
+ * @param habit - The habit to check
+ * @param completions - All completions to filter (may include other habits or other weeks)
+ * @param weekStart - The Monday (start) of the week to evaluate
+ * @returns The number of completions in the week and the target count
+ */
+export function getWeeklyProgress(
+  habit: Habit,
+  completions: readonly Completion[],
+  weekStart: Date,
+): WeeklyProgress {
+  const target = getWeeklyTarget(habit);
+  const done = countCompletionsInWeek(habit.id, completions, weekStart);
+
+  return { done, target };
+}
+
+function getWeeklyTarget(habit: Habit): number {
+  const { frequency } = habit;
+
+  switch (frequency.type) {
+    case 'daily':
+      return DAYS_IN_WEEK;
+    case 'weekly_days':
+      return frequency.days.length;
+    case 'weekly_count':
+      return frequency.count;
+  }
+}
+
+function countCompletionsInWeek(
+  habitId: string,
+  completions: readonly Completion[],
+  weekStart: Date,
+): number {
+  const startStr = formatDate(weekStart);
+  const weekEnd = new Date(weekStart);
+  weekEnd.setDate(weekEnd.getDate() + DAYS_IN_WEEK - 1);
+  const endStr = formatDate(weekEnd);
+
+  return completions.filter(
+    (c) =>
+      c.habitId === habitId &&
+      c.completedDate >= startStr &&
+      c.completedDate <= endStr,
+  ).length;
+}
+
+function formatDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- `isDueToday(habit, date): boolean` を実装。頻度タイプ（daily / weekly_days / weekly_count）に基づき、指定日に習慣を実施すべきか判定する
- `getWeeklyProgress(habit, completions, weekStart): WeeklyProgress` を実装。週の完了数とターゲット数を計算する
- 全関数をピュア関数として実装（外部依存なし、Date.now()不使用）

Closes #3

## 変更ファイル
- `src/domain/services/frequencyService.ts` - FrequencyService本体
- `src/domain/services/__tests__/frequencyService.test.ts` - ユニットテスト（17ケース）

## テスト計画
- [x] isDueToday: daily頻度で任意の日にtrue
- [x] isDueToday: weekly_days頻度で指定曜日にtrue / 非指定曜日にfalse
- [x] isDueToday: weekly_days頻度で日曜(0)の境界ケース
- [x] isDueToday: weekly_count頻度で任意の日にtrue
- [x] getWeeklyProgress: weekly_count頻度で完了数とターゲット数を正しく返す
- [x] getWeeklyProgress: daily頻度でtarget=7を返す
- [x] getWeeklyProgress: weekly_days頻度でtarget=指定日数を返す
- [x] getWeeklyProgress: 空のcompletions配列を処理
- [x] getWeeklyProgress: 週外のcompletionsを除外
- [x] getWeeklyProgress: 他のhabitのcompletionsを除外
- [x] テストカバレッジ100%（Statements/Branches/Functions/Lines）