### PR TITLE
feat: useHabitsフック実装

### DIFF
--- a/src/hooks/__tests__/useHabits.test.ts
+++ b/src/hooks/__tests__/useHabits.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for useHabits hook.
+ *
+ * Since the test environment is Node (no DOM/react-dom),
+ * we test the underlying HabitsManager class which contains
+ * all the business logic that the hook delegates to.
+ */
+import type { Habit, CreateHabitInput } from '../../domain/models';
+import type { HabitRepository, UpdateHabitInput } from '../../data/repositories';
+import { HabitsManager, type HabitsState } from '../habitsManager';
+
+// --- Test fixtures ---
+
+const SAMPLE_HABIT_1: Habit = {
+  id: 'habit-1',
+  name: 'Morning Run',
+  frequency: { type: 'daily' },
+  color: '#FF0000',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  archivedAt: null,
+};
+
+const SAMPLE_HABIT_2: Habit = {
+  id: 'habit-2',
+  name: 'Yoga',
+  frequency: { type: 'weekly_days', days: [1, 3, 5] },
+  color: '#00FF00',
+  createdAt: '2026-01-02T00:00:00.000Z',
+  archivedAt: null,
+};
+
+// --- Mock repository ---
+
+function createMockRepository(): jest.Mocked<HabitRepository> {
+  return {
+    findAll: jest.fn().mockResolvedValue([]),
+    findById: jest.fn().mockResolvedValue(null),
+    create: jest.fn().mockResolvedValue(SAMPLE_HABIT_1),
+    update: jest.fn().mockResolvedValue(SAMPLE_HABIT_1),
+    archive: jest.fn().mockResolvedValue(undefined),
+    findArchived: jest.fn().mockResolvedValue([]),
+  };
+}
+
+// --- Tests ---
+
+describe('HabitsManager', () => {
+  let mockRepo: jest.Mocked<HabitRepository>;
+  let states: HabitsState[];
+  let manager: HabitsManager;
+
+  beforeEach(() => {
+    mockRepo = createMockRepository();
+    states = [];
+    manager = new HabitsManager(mockRepo, (state) => {
+      states.push(state);
+    });
+  });
+
+  describe('initial state', () => {
+    it('should have correct initial state', () => {
+      const state = manager.getState();
+      expect(state).toEqual({
+        habits: [],
+        isLoading: false,
+        error: null,
+      });
+    });
+  });
+
+  describe('loadHabits', () => {
+    it('should load habits and update state', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1, SAMPLE_HABIT_2]);
+
+      await manager.loadHabits();
+
+      const finalState = manager.getState();
+      expect(finalState.habits).toEqual([SAMPLE_HABIT_1, SAMPLE_HABIT_2]);
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.error).toBeNull();
+    });
+
+    it('should set isLoading to true while loading', async () => {
+      mockRepo.findAll.mockResolvedValue([]);
+
+      const promise = manager.loadHabits();
+
+      // Check that loading state was emitted
+      const loadingState = states.find((s) => s.isLoading);
+      expect(loadingState).toBeDefined();
+      expect(loadingState!.isLoading).toBe(true);
+
+      await promise;
+    });
+
+    it('should set error when loading fails', async () => {
+      mockRepo.findAll.mockRejectedValue(new Error('DB connection failed'));
+
+      await manager.loadHabits();
+
+      const finalState = manager.getState();
+      expect(finalState.error).toBe('DB connection failed');
+      expect(finalState.isLoading).toBe(false);
+      expect(finalState.habits).toEqual([]);
+    });
+
+    it('should handle non-Error thrown values', async () => {
+      mockRepo.findAll.mockRejectedValue('string error');
+
+      await manager.loadHabits();
+
+      const finalState = manager.getState();
+      expect(finalState.error).toBe('Failed to load habits');
+      expect(finalState.isLoading).toBe(false);
+    });
+  });
+
+  describe('createHabit', () => {
+    it('should create a habit and refresh the list', async () => {
+      const input: CreateHabitInput = {
+        name: 'Meditation',
+        frequency: { type: 'daily' },
+        color: '#AABBCC',
+      };
+      const createdHabit: Habit = {
+        id: 'new-id',
+        name: 'Meditation',
+        frequency: { type: 'daily' },
+        color: '#AABBCC',
+        createdAt: '2026-03-15T00:00:00.000Z',
+        archivedAt: null,
+      };
+
+      mockRepo.create.mockResolvedValue(createdHabit);
+      mockRepo.findAll.mockResolvedValue([createdHabit]);
+
+      await manager.createHabit(input);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(input);
+      expect(mockRepo.findAll).toHaveBeenCalled();
+      expect(manager.getState().habits).toEqual([createdHabit]);
+    });
+
+    it('should set error when creation fails', async () => {
+      mockRepo.create.mockRejectedValue(new Error('Insert failed'));
+
+      await manager.createHabit({
+        name: 'Test',
+        frequency: { type: 'daily' },
+        color: '#000000',
+      });
+
+      expect(manager.getState().error).toBe('Insert failed');
+      expect(manager.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('updateHabit', () => {
+    it('should update a habit and refresh the list', async () => {
+      const updatedHabit: Habit = {
+        ...SAMPLE_HABIT_1,
+        name: 'Evening Run',
+      };
+      mockRepo.update.mockResolvedValue(updatedHabit);
+      mockRepo.findAll.mockResolvedValue([updatedHabit]);
+
+      await manager.updateHabit('habit-1', { name: 'Evening Run' });
+
+      expect(mockRepo.update).toHaveBeenCalledWith('habit-1', {
+        name: 'Evening Run',
+      });
+      expect(mockRepo.findAll).toHaveBeenCalled();
+      expect(manager.getState().habits).toEqual([updatedHabit]);
+    });
+
+    it('should set error when update fails', async () => {
+      mockRepo.update.mockRejectedValue(new Error('Update failed'));
+
+      await manager.updateHabit('habit-1', { name: 'Test' });
+
+      expect(manager.getState().error).toBe('Update failed');
+    });
+  });
+
+  describe('archiveHabit', () => {
+    it('should archive a habit and refresh the list', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_2]);
+
+      await manager.archiveHabit('habit-1');
+
+      expect(mockRepo.archive).toHaveBeenCalledWith('habit-1');
+      expect(mockRepo.findAll).toHaveBeenCalled();
+      expect(manager.getState().habits).toEqual([SAMPLE_HABIT_2]);
+    });
+
+    it('should set error when archive fails', async () => {
+      mockRepo.archive.mockRejectedValue(new Error('Archive failed'));
+
+      await manager.archiveHabit('habit-1');
+
+      expect(manager.getState().error).toBe('Archive failed');
+    });
+  });
+
+  describe('refresh', () => {
+    it('should reload habits from repository', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1]);
+
+      await manager.refresh();
+
+      expect(mockRepo.findAll).toHaveBeenCalled();
+      expect(manager.getState().habits).toEqual([SAMPLE_HABIT_1]);
+    });
+  });
+
+  describe('state immutability', () => {
+    it('should return new state objects on each update', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1]);
+
+      const stateBefore = manager.getState();
+      await manager.loadHabits();
+      const stateAfter = manager.getState();
+
+      expect(stateBefore).not.toBe(stateAfter);
+    });
+
+    it('should not mutate the habits array', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1]);
+      await manager.loadHabits();
+
+      const habitsRef = manager.getState().habits;
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1, SAMPLE_HABIT_2]);
+      await manager.loadHabits();
+
+      // Original reference should be unchanged
+      expect(habitsRef).toEqual([SAMPLE_HABIT_1]);
+      expect(manager.getState().habits).toEqual([
+        SAMPLE_HABIT_1,
+        SAMPLE_HABIT_2,
+      ]);
+    });
+  });
+
+  describe('error clearing', () => {
+    it('should clear error on successful operation after failure', async () => {
+      mockRepo.findAll.mockRejectedValueOnce(new Error('Temporary error'));
+      await manager.loadHabits();
+      expect(manager.getState().error).toBe('Temporary error');
+
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1]);
+      await manager.loadHabits();
+      expect(manager.getState().error).toBeNull();
+    });
+  });
+
+  describe('state notification', () => {
+    it('should call onStateChange for each state transition', async () => {
+      mockRepo.findAll.mockResolvedValue([SAMPLE_HABIT_1]);
+
+      await manager.loadHabits();
+
+      // Should have at least 2 state changes: loading=true, then loading=false with habits
+      expect(states.length).toBeGreaterThanOrEqual(2);
+      expect(states[0].isLoading).toBe(true);
+      expect(states[states.length - 1].isLoading).toBe(false);
+      expect(states[states.length - 1].habits).toEqual([SAMPLE_HABIT_1]);
+    });
+  });
+});

--- a/src/hooks/habitsManager.ts
+++ b/src/hooks/habitsManager.ts
@@ -1,0 +1,130 @@
+/**
+ * HabitsManager - Core state management logic for habit CRUD operations.
+ *
+ * Decoupled from React to enable unit testing without DOM/react-dom.
+ * The useHabits hook wraps this manager to provide React state integration.
+ */
+
+import type { Habit, CreateHabitInput } from '../domain/models';
+import type { HabitRepository, UpdateHabitInput } from '../data/repositories';
+
+// --- State type ---
+
+export type HabitsState = {
+  readonly habits: readonly Habit[];
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const INITIAL_STATE: HabitsState = {
+  habits: [],
+  isLoading: false,
+  error: null,
+};
+
+// --- Constants ---
+
+const DEFAULT_ERROR_MESSAGE = 'Failed to load habits';
+const CREATE_ERROR_MESSAGE = 'Failed to create habit';
+const UPDATE_ERROR_MESSAGE = 'Failed to update habit';
+const ARCHIVE_ERROR_MESSAGE = 'Failed to archive habit';
+
+// --- Utility ---
+
+export type StateChangeCallback = (state: HabitsState) => void;
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return fallback;
+}
+
+// --- HabitsManager ---
+
+/**
+ * HabitsManager encapsulates habit CRUD state management logic.
+ * Notifies the caller of state changes via the onStateChange callback.
+ */
+export class HabitsManager {
+  private state: HabitsState;
+  private readonly repository: HabitRepository;
+  private readonly onStateChange: StateChangeCallback;
+
+  constructor(repository: HabitRepository, onStateChange: StateChangeCallback) {
+    this.state = INITIAL_STATE;
+    this.repository = repository;
+    this.onStateChange = onStateChange;
+  }
+
+  getState(): HabitsState {
+    return this.state;
+  }
+
+  private setState(partial: Partial<HabitsState>): void {
+    this.state = {
+      ...this.state,
+      ...partial,
+    };
+    this.onStateChange(this.state);
+  }
+
+  async loadHabits(): Promise<void> {
+    this.setState({ isLoading: true, error: null });
+    try {
+      const habits = await this.repository.findAll();
+      this.setState({ habits, isLoading: false });
+    } catch (error: unknown) {
+      this.setState({
+        isLoading: false,
+        error: extractErrorMessage(error, DEFAULT_ERROR_MESSAGE),
+      });
+    }
+  }
+
+  async createHabit(input: CreateHabitInput): Promise<void> {
+    this.setState({ isLoading: true, error: null });
+    try {
+      await this.repository.create(input);
+      const habits = await this.repository.findAll();
+      this.setState({ habits, isLoading: false });
+    } catch (error: unknown) {
+      this.setState({
+        isLoading: false,
+        error: extractErrorMessage(error, CREATE_ERROR_MESSAGE),
+      });
+    }
+  }
+
+  async updateHabit(id: string, input: UpdateHabitInput): Promise<void> {
+    this.setState({ isLoading: true, error: null });
+    try {
+      await this.repository.update(id, input);
+      const habits = await this.repository.findAll();
+      this.setState({ habits, isLoading: false });
+    } catch (error: unknown) {
+      this.setState({
+        isLoading: false,
+        error: extractErrorMessage(error, UPDATE_ERROR_MESSAGE),
+      });
+    }
+  }
+
+  async archiveHabit(id: string): Promise<void> {
+    this.setState({ isLoading: true, error: null });
+    try {
+      await this.repository.archive(id);
+      const habits = await this.repository.findAll();
+      this.setState({ habits, isLoading: false });
+    } catch (error: unknown) {
+      this.setState({
+        isLoading: false,
+        error: extractErrorMessage(error, ARCHIVE_ERROR_MESSAGE),
+      });
+    }
+  }
+
+  async refresh(): Promise<void> {
+    return this.loadHabits();
+  }
+}

--- a/src/hooks/useHabits.ts
+++ b/src/hooks/useHabits.ts
@@ -1,0 +1,74 @@
+/**
+ * useHabits - Custom React hook for habit CRUD operations.
+ *
+ * Thin React wrapper around HabitsManager.
+ * Provides habit list, loading/error state, and mutation functions.
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { CreateHabitInput } from '../domain/models';
+import type { HabitRepository, UpdateHabitInput } from '../data/repositories';
+import { HabitsManager, INITIAL_STATE, type HabitsState } from './habitsManager';
+
+// Re-export for convenience
+export { HabitsManager, type HabitsState } from './habitsManager';
+
+export type UseHabitsReturn = {
+  readonly habits: HabitsState['habits'];
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly createHabit: (input: CreateHabitInput) => Promise<void>;
+  readonly updateHabit: (id: string, input: UpdateHabitInput) => Promise<void>;
+  readonly archiveHabit: (id: string) => Promise<void>;
+  readonly refresh: () => Promise<void>;
+};
+
+/**
+ * React hook providing habit CRUD operations and state.
+ *
+ * @param repository - HabitRepository instance (injected for testability)
+ * @returns Habit state and mutation functions
+ */
+export function useHabits(repository: HabitRepository): UseHabitsReturn {
+  const [state, setState] = useState<HabitsState>(INITIAL_STATE);
+  const managerRef = useRef<HabitsManager | null>(null);
+
+  if (managerRef.current === null) {
+    managerRef.current = new HabitsManager(repository, (newState) => {
+      setState(newState);
+    });
+  }
+
+  const manager = managerRef.current;
+
+  useEffect(() => {
+    void manager.loadHabits();
+  }, [manager]);
+
+  const createHabit = useCallback(
+    (input: CreateHabitInput) => manager.createHabit(input),
+    [manager]
+  );
+
+  const updateHabit = useCallback(
+    (id: string, input: UpdateHabitInput) => manager.updateHabit(id, input),
+    [manager]
+  );
+
+  const archiveHabit = useCallback(
+    (id: string) => manager.archiveHabit(id),
+    [manager]
+  );
+
+  const refresh = useCallback(() => manager.refresh(), [manager]);
+
+  return {
+    habits: state.habits,
+    isLoading: state.isLoading,
+    error: state.error,
+    createHabit,
+    updateHabit,
+    archiveHabit,
+    refresh,
+  };
+}


### PR DESCRIPTION
## 概要

Closes #8

HabitRepositoryを使って習慣のCRUD操作をReactコンポーネントに提供するカスタムフック `useHabits` を実装しました。

## 変更内容

- **`src/hooks/habitsManager.ts`**: コアロジック（HabitsManagerクラス）
  - 習慣一覧の取得（loadHabits / refresh）
  - 習慣の作成（createHabit）
  - 習慣の更新（updateHabit）
  - 習慣のアーカイブ（archiveHabit）
  - ローディング状態・エラー状態の管理
  - イミュータブルな状態遷移
  - React非依存でテスト可能

- **`src/hooks/useHabits.ts`**: Reactフック（薄いラッパー）
  - HabitsManagerをReact状態と統合
  - useRef/useCallback/useEffectでReactライフサイクルに接続
  - HabitRepositoryをDIで受け取る設計

- **`src/hooks/__tests__/useHabits.test.ts`**: ユニットテスト（16テスト）
  - HabitsManagerの全メソッドをテスト
  - エラーハンドリング（Error, non-Error）
  - 状態の不変性検証
  - エラークリア動作
  - 状態変更通知

## 設計判断

- **HabitsManager分離**: テスト環境がNode（react-dom/React Testing Library未導入）のため、Reactフックのロジックを純粋なTypeScriptクラスに抽出。これによりDOM不要で100%カバレッジを達成
- **DI設計**: `useHabits(repository)` でリポジトリを注入。テスト時のモック、将来のContext対応が容易
- **操作後の自動リフレッシュ**: create/update/archive後に `findAll()` で一覧を再取得し、UIの一貫性を保証

## テスト計画

- [x] HabitsManager全メソッドのユニットテスト（16テスト、カバレッジ100%）
- [x] エラーハンドリングのテスト（Error/non-Error両方）
- [x] 状態イミュータビリティのテスト
- [x] 既存テスト全パス確認（177テスト）
- [x] TypeScript型チェック通過