### PR TITLE
feat: Supabase設定（クライアント、テーブル、RLS） #34

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Supabase Configuration
+# Get these values from your Supabase project dashboard:
+# https://app.supabase.com/project/_/settings/api
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist/
 .env
 .env.*
 .env.local
+!.env.example
 
 # debug
 npm-debug.*

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -1,0 +1,106 @@
+# Supabase セットアップ手順
+
+## 1. Supabaseプロジェクトの作成
+
+1. [Supabase Dashboard](https://app.supabase.com/) にアクセス
+2. 「New Project」をクリック
+3. プロジェクト名、データベースパスワード、リージョン（Northeast Asia - Tokyo推奨）を設定
+4. 「Create new project」をクリック
+
+## 2. 環境変数の設定
+
+プロジェクトダッシュボードの **Settings > API** から以下の値を取得する。
+
+```bash
+cp .env.example .env
+```
+
+`.env` ファイルを編集:
+
+```
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIs...
+```
+
+- `VITE_SUPABASE_URL`: Project URL
+- `VITE_SUPABASE_ANON_KEY`: Project API keys > anon public
+
+## 3. データベースマイグレーション
+
+### Supabase CLIを使う場合（推奨）
+
+```bash
+# Supabase CLIのインストール
+npm install -g supabase
+
+# ローカル開発環境の初期化
+npx supabase init
+npx supabase start
+
+# マイグレーションの実行（ローカル）
+npx supabase db reset
+
+# 本番環境へのマイグレーション
+npx supabase link --project-ref your-project-ref
+npx supabase db push
+```
+
+### SQL Editorを使う場合
+
+Supabase Dashboard の **SQL Editor** で `supabase/migrations/20260315000000_create_tables.sql` の内容を実行する。
+
+## 4. 認証プロバイダーの設定（Google OAuth）
+
+1. **Authentication > Providers** で Google を有効化
+2. [Google Cloud Console](https://console.cloud.google.com/) で OAuth 2.0 クライアントIDを作成
+3. リダイレクトURIに `https://your-project-ref.supabase.co/auth/v1/callback` を追加
+4. Client ID と Client Secret を Supabase に設定
+
+## 5. テーブル構成
+
+### profiles
+
+| カラム | 型 | 説明 |
+|--------|------|------|
+| id | UUID | 主キー（auth.users.id） |
+| display_name | TEXT | 表示名 |
+| created_at | TIMESTAMPTZ | 作成日時 |
+
+- ユーザー登録時にトリガーで自動作成
+
+### habits
+
+| カラム | 型 | 説明 |
+|--------|------|------|
+| id | UUID | 主キー |
+| user_id | UUID | FK -> auth.users.id |
+| name | TEXT | 習慣名 |
+| frequency_type | TEXT | daily / weekly_days / weekly_count |
+| frequency_value | JSONB | 頻度の詳細値 |
+| color | TEXT | 表示色（HEX） |
+| created_at | TIMESTAMPTZ | 作成日時 |
+| archived_at | TIMESTAMPTZ | アーカイブ日時 |
+
+### completions
+
+| カラム | 型 | 説明 |
+|--------|------|------|
+| id | UUID | 主キー |
+| user_id | UUID | FK -> auth.users.id |
+| habit_id | UUID | FK -> habits.id |
+| completed_date | DATE | 完了日 |
+| created_at | TIMESTAMPTZ | 記録日時 |
+
+- `(habit_id, completed_date)` にユニーク制約
+
+## 6. Row Level Security (RLS)
+
+全テーブルでRLSが有効化されており、`auth.uid() = user_id`（profilesは`auth.uid() = id`）で自分のデータのみアクセス可能。
+
+## 7. 型定義の再生成
+
+テーブル構造を変更した場合、型定義を再生成する:
+
+```bash
+npx supabase gen types typescript --linked > src/lib/database.types.ts
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/geist": "^5.2.8",
+        "@supabase/supabase-js": "^2.99.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -2211,6 +2212,86 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.99.1.tgz",
+      "integrity": "sha512-x7lKKTvKjABJt/FYcRSPiTT01Xhm2FF8RhfL8+RHMkmlwmRQ88/lREupIHKwFPW0W6pTCJqkZb7Yhpw/EZ+fNw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.99.1.tgz",
+      "integrity": "sha512-WQE62W5geYImCO4jzFxCk/avnK7JmOdtqu2eiPz3zOaNiIJajNRSAwMMDgEGd2EMs+sUVYj1LfBjfmW3EzHgIA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.99.1.tgz",
+      "integrity": "sha512-gtw2ibJrADvfqrpUWXGNlrYUvxttF4WVWfPpTFKOb2IRj7B6YRWMDgcrYqIuD4ZEabK4m6YKQCCGy6clgf1lPA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.99.1.tgz",
+      "integrity": "sha512-9EDdy/5wOseGFqxW88ShV9JMRhm7f+9JGY5x+LqT8c7R0X1CTLwg5qie8FiBWcXTZ+68yYxVWunI+7W4FhkWOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.99.1.tgz",
+      "integrity": "sha512-mf7zPfqofI62SOoyQJeNUVxe72E4rQsbWim6lTDPeLu3lHija/cP5utlQADGrjeTgOUN6znx/rWn7SjrETP1dw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.99.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.99.1.tgz",
+      "integrity": "sha512-5MRoYD9ffXq8F6a036dm65YoSHisC3by/d22mauKE99Vrwf792KxYIIr/iqCX7E4hkuugbPZ5EGYHTB7MKy6Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.99.1",
+        "@supabase/functions-js": "2.99.1",
+        "@supabase/postgrest-js": "2.99.1",
+        "@supabase/realtime-js": "2.99.1",
+        "@supabase/storage-js": "2.99.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -2582,6 +2663,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2613,6 +2709,15 @@
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.0",
@@ -4983,6 +5088,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -7675,6 +7789,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -8000,6 +8120,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@fontsource-variable/geist": "^5.2.8",
+    "@supabase/supabase-js": "^2.99.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",

--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('createSupabaseClient', () => {
+  const originalEnv = { ...import.meta.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Object.keys(import.meta.env).forEach((key) => {
+      if (key.startsWith('VITE_SUPABASE_')) {
+        delete (import.meta.env as Record<string, string>)[key];
+      }
+    });
+    Object.assign(import.meta.env, originalEnv);
+  });
+
+  it('should throw an error when VITE_SUPABASE_URL is not set', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_ANON_KEY =
+      'test-anon-key';
+
+    const { createSupabaseClient } = await import('../supabase');
+    expect(() => createSupabaseClient()).toThrow(
+      'VITE_SUPABASE_URL is not configured'
+    );
+  });
+
+  it('should throw an error when VITE_SUPABASE_ANON_KEY is not set', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_URL =
+      'https://test.supabase.co';
+
+    const { createSupabaseClient } = await import('../supabase');
+    expect(() => createSupabaseClient()).toThrow(
+      'VITE_SUPABASE_ANON_KEY is not configured'
+    );
+  });
+
+  it('should throw when both environment variables are empty strings', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_URL = '';
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_ANON_KEY = '';
+
+    const { createSupabaseClient } = await import('../supabase');
+    expect(() => createSupabaseClient()).toThrow(
+      'VITE_SUPABASE_URL is not configured'
+    );
+  });
+
+  it('should create a Supabase client when environment variables are set', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_URL =
+      'https://test.supabase.co';
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_ANON_KEY =
+      'test-anon-key';
+
+    const { createSupabaseClient } = await import('../supabase');
+    const client = createSupabaseClient();
+    expect(client).toBeDefined();
+    expect(typeof client.from).toBe('function');
+    expect(typeof client.auth).toBe('object');
+  });
+});
+
+describe('getSupabaseConfig', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    Object.keys(import.meta.env).forEach((key) => {
+      if (key.startsWith('VITE_SUPABASE_')) {
+        delete (import.meta.env as Record<string, string>)[key];
+      }
+    });
+  });
+
+  it('should return the Supabase configuration', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_URL =
+      'https://test.supabase.co';
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_ANON_KEY =
+      'test-anon-key';
+
+    const { getSupabaseConfig } = await import('../supabase');
+    const config = getSupabaseConfig();
+    expect(config).toEqual({
+      url: 'https://test.supabase.co',
+      anonKey: 'test-anon-key',
+    });
+  });
+
+  it('should throw when URL is missing', async () => {
+    (import.meta.env as Record<string, string>).VITE_SUPABASE_ANON_KEY =
+      'test-anon-key';
+
+    const { getSupabaseConfig } = await import('../supabase');
+    expect(() => getSupabaseConfig()).toThrow(
+      'VITE_SUPABASE_URL is not configured'
+    );
+  });
+});

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,0 +1,124 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      profiles: {
+        Row: {
+          id: string;
+          display_name: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id: string;
+          display_name?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          display_name?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+      habits: {
+        Row: {
+          id: string;
+          user_id: string;
+          name: string;
+          frequency_type: string;
+          frequency_value: Json | null;
+          color: string;
+          created_at: string;
+          archived_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          name: string;
+          frequency_type: string;
+          frequency_value?: Json | null;
+          color: string;
+          created_at?: string;
+          archived_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          name?: string;
+          frequency_type?: string;
+          frequency_value?: Json | null;
+          color?: string;
+          created_at?: string;
+          archived_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'habits_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+      completions: {
+        Row: {
+          id: string;
+          user_id: string;
+          habit_id: string;
+          completed_date: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          habit_id: string;
+          completed_date: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          habit_id?: string;
+          completed_date?: string;
+          created_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'completions_user_id_fkey';
+            columns: ['user_id'];
+            isOneToOne: false;
+            referencedRelation: 'users';
+            referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'completions_habit_id_fkey';
+            columns: ['habit_id'];
+            isOneToOne: false;
+            referencedRelation: 'habits';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,27 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from './database.types';
+
+interface SupabaseConfig {
+  readonly url: string;
+  readonly anonKey: string;
+}
+
+const validateEnvVar = (name: string): string => {
+  const value = import.meta.env[name] as string | undefined;
+  if (!value) {
+    throw new Error(
+      `${name} is not configured. Please set it in your .env file.`
+    );
+  }
+  return value;
+};
+
+export const getSupabaseConfig = (): SupabaseConfig => ({
+  url: validateEnvVar('VITE_SUPABASE_URL'),
+  anonKey: validateEnvVar('VITE_SUPABASE_ANON_KEY'),
+});
+
+export const createSupabaseClient = (): SupabaseClient<Database> => {
+  const config = getSupabaseConfig();
+  return createClient<Database>(config.url, config.anonKey);
+};

--- a/supabase/migrations/20260315000000_create_tables.sql
+++ b/supabase/migrations/20260315000000_create_tables.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- daily-rituals: Initial table creation
+-- ============================================================
+
+-- --------------------------------------------------------
+-- profiles: User profile linked to Supabase Auth
+-- --------------------------------------------------------
+CREATE TABLE profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  display_name TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own profile"
+  ON profiles FOR SELECT
+  USING (auth.uid() = id);
+
+CREATE POLICY "Users can insert own profile"
+  ON profiles FOR INSERT
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile"
+  ON profiles FOR UPDATE
+  USING (auth.uid() = id);
+
+-- Auto-create profile on user signup
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, display_name)
+  VALUES (
+    NEW.id,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.raw_user_meta_data->>'name')
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE FUNCTION public.handle_new_user();
+
+-- --------------------------------------------------------
+-- habits: User habits with frequency settings
+-- --------------------------------------------------------
+CREATE TABLE habits (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  frequency_type TEXT NOT NULL CHECK (frequency_type IN ('daily', 'weekly_days', 'weekly_count')),
+  frequency_value JSONB,
+  color TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  archived_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_habits_user_id ON habits(user_id);
+
+ALTER TABLE habits ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can CRUD own habits"
+  ON habits FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- --------------------------------------------------------
+-- completions: Habit completion records
+-- --------------------------------------------------------
+CREATE TABLE completions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  habit_id UUID NOT NULL REFERENCES habits(id) ON DELETE CASCADE,
+  completed_date DATE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_completions_habit_date UNIQUE (habit_id, completed_date)
+);
+
+CREATE INDEX idx_completions_user_id ON completions(user_id);
+CREATE INDEX idx_completions_habit_id ON completions(habit_id);
+CREATE INDEX idx_completions_completed_date ON completions(completed_date);
+
+ALTER TABLE completions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can CRUD own completions"
+  ON completions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
         'src/data/repositories/completionRepository.ts',
         'src/data/repositories/index.ts',
         'src/hooks/index.ts',
+        'src/lib/database.types.ts',
       ],
       thresholds: {
         branches: 80,


### PR DESCRIPTION
## 概要

Supabaseクライアントの初期化、データベーステーブル定義（SQLマイグレーション）、Row Level Security (RLS) ポリシーを設定する。

Closes #34

## 変更内容

- `@supabase/supabase-js` をdependenciesに追加
- `src/lib/supabase.ts`: 環境変数（`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`）からSupabaseクライアントを初期化。未設定時は明確なエラーメッセージをthrow
- `src/lib/database.types.ts`: profiles / habits / completions テーブルのTypeScript型定義
- `supabase/migrations/20260315000000_create_tables.sql`:
  - profiles テーブル（auth.usersへのFK、トリガーで自動作成）
  - habits テーブル（frequency_type CHECK制約、user_idインデックス）
  - completions テーブル（`(habit_id, completed_date)` ユニーク制約）
  - 全テーブルにRLSポリシー（`auth.uid() = user_id`）
- `.env.example`: Supabase環境変数のテンプレート
- `.gitignore`: `!.env.example` を追加（`.env.*` から除外）
- `docs/supabase-setup.md`: Supabaseプロジェクトのセットアップ手順
- `vite.config.ts`: coverage除外に`database.types.ts`を追加

## テスト計画

- [x] `createSupabaseClient`: 環境変数未設定時にエラーをthrowすることを確認（3ケース）
- [x] `createSupabaseClient`: 環境変数設定時にクライアントが作成されることを確認
- [x] `getSupabaseConfig`: 設定値の取得と未設定時のエラーを確認
- [x] 全既存テスト（210件）がパスすること
- [x] TypeScript型チェック（`tsc --noEmit`）がパスすること