### PR TITLE
feat: 習慣一覧・フォーム画面の実装

### DIFF
--- a/src/ui/components/HabitCard.tsx
+++ b/src/ui/components/HabitCard.tsx
@@ -1,0 +1,54 @@
+/**
+ * HabitCard - Displays a single habit with name, frequency, color, and action buttons.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import type { Habit } from '@/domain/models/habit';
+import { formatFrequency } from '@/domain/services/frequencyDisplayService';
+
+type HabitCardProps = {
+  readonly habit: Habit;
+  readonly onArchive: (id: string) => void;
+  readonly isArchived: boolean;
+};
+
+export function HabitCard({ habit, onArchive, isArchived }: HabitCardProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 shadow-sm transition-colors hover:bg-muted/30">
+      <div
+        className="h-4 w-4 shrink-0 rounded-full"
+        style={{ backgroundColor: habit.color }}
+        aria-hidden="true"
+      />
+
+      <Link
+        to={`/habits/${habit.id}`}
+        className="flex min-w-0 flex-1 flex-col"
+      >
+        <span
+          className={`text-sm font-medium ${isArchived ? 'text-muted-foreground line-through' : 'text-foreground'}`}
+        >
+          {habit.name}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {formatFrequency(habit.frequency)}
+        </span>
+      </Link>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onArchive(habit.id)}
+        aria-label={
+          isArchived
+            ? `${habit.name}をアーカイブ解除`
+            : `${habit.name}をアーカイブ`
+        }
+      >
+        {isArchived ? '復元' : 'アーカイブ'}
+      </Button>
+    </div>
+  );
+}

--- a/src/ui/components/HabitForm.tsx
+++ b/src/ui/components/HabitForm.tsx
@@ -1,0 +1,289 @@
+/**
+ * HabitForm - Shared form component for creating and editing habits.
+ *
+ * Handles habit name, frequency type, day selection, count input, and color selection.
+ * Uses Zod validation from domain layer.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import type { HabitFormState, FrequencyType } from '@/domain/models/habitFormValidation';
+import {
+  INITIAL_FORM_STATE,
+  PRESET_COLORS,
+  FREQUENCY_TYPES,
+  FREQUENCY_TYPE_LABELS,
+  DAY_LABELS,
+  validateHabitForm,
+} from '@/domain/models/habitFormValidation';
+
+// --- Types ---
+
+type HabitFormProps = {
+  readonly initialState?: HabitFormState;
+  readonly onSubmit: (state: HabitFormState) => void;
+  readonly isSubmitting: boolean;
+  readonly submitLabel: string;
+};
+
+type FieldErrors = Readonly<Record<string, string>>;
+
+// --- Sub-components ---
+
+function FormField({
+  label,
+  error,
+  children,
+}: {
+  readonly label: string;
+  readonly error?: string;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-sm font-medium text-foreground">{label}</label>
+      {children}
+      {error && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NameInput({
+  value,
+  onChange,
+  error,
+}: {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly error?: string;
+}) {
+  return (
+    <FormField label="習慣名" error={error}>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="例: 読書する"
+        className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        aria-invalid={error ? 'true' : 'false'}
+      />
+    </FormField>
+  );
+}
+
+function FrequencyTypeSelector({
+  value,
+  onChange,
+}: {
+  readonly value: FrequencyType;
+  readonly onChange: (value: FrequencyType) => void;
+}) {
+  return (
+    <FormField label="頻度">
+      <div className="flex gap-2">
+        {FREQUENCY_TYPES.map((type) => (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onChange(type)}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              value === type
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            }`}
+            aria-pressed={value === type}
+          >
+            {FREQUENCY_TYPE_LABELS[type]}
+          </button>
+        ))}
+      </div>
+    </FormField>
+  );
+}
+
+function DaySelector({
+  selectedDays,
+  onChange,
+  error,
+}: {
+  readonly selectedDays: readonly number[];
+  readonly onChange: (days: readonly number[]) => void;
+  readonly error?: string;
+}) {
+  const toggleDay = useCallback(
+    (day: number) => {
+      const isSelected = selectedDays.includes(day);
+      const newDays = isSelected
+        ? selectedDays.filter((d) => d !== day)
+        : [...selectedDays, day];
+      onChange(newDays);
+    },
+    [selectedDays, onChange],
+  );
+
+  return (
+    <FormField label="曜日を選択" error={error}>
+      <div className="flex gap-1.5">
+        {DAY_LABELS.map((label, index) => (
+          <button
+            key={index}
+            type="button"
+            onClick={() => toggleDay(index)}
+            className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-medium transition-colors ${
+              selectedDays.includes(index)
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80'
+            }`}
+            aria-pressed={selectedDays.includes(index)}
+            aria-label={`${label}曜日`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </FormField>
+  );
+}
+
+function CountInput({
+  value,
+  onChange,
+  error,
+}: {
+  readonly value: number;
+  readonly onChange: (value: number) => void;
+  readonly error?: string;
+}) {
+  return (
+    <FormField label="週の回数" error={error}>
+      <input
+        type="number"
+        min={1}
+        max={7}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex h-9 w-24 rounded-md border border-input bg-background px-3 py-1 text-sm text-foreground shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        aria-invalid={error ? 'true' : 'false'}
+      />
+    </FormField>
+  );
+}
+
+function ColorSelector({
+  value,
+  onChange,
+  error,
+}: {
+  readonly value: string;
+  readonly onChange: (value: string) => void;
+  readonly error?: string;
+}) {
+  return (
+    <FormField label="色" error={error}>
+      <div className="flex gap-2">
+        {PRESET_COLORS.map((color) => (
+          <button
+            key={color}
+            type="button"
+            onClick={() => onChange(color)}
+            className={`h-8 w-8 rounded-full border-2 transition-transform ${
+              value === color
+                ? 'scale-110 border-foreground'
+                : 'border-transparent hover:scale-105'
+            }`}
+            style={{ backgroundColor: color }}
+            aria-label={`色: ${color}`}
+            aria-pressed={value === color}
+          />
+        ))}
+      </div>
+    </FormField>
+  );
+}
+
+// --- Main component ---
+
+export function HabitForm({
+  initialState,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+}: HabitFormProps) {
+  const [formState, setFormState] = useState<HabitFormState>(
+    initialState ?? INITIAL_FORM_STATE,
+  );
+  const [errors, setErrors] = useState<FieldErrors>({});
+
+  const updateField = useCallback(
+    <K extends keyof HabitFormState>(field: K, value: HabitFormState[K]) => {
+      setFormState((prev) => ({ ...prev, [field]: value }));
+      setErrors((prev) => {
+        if (field in prev) {
+          const { [field as string]: _, ...rest } = prev;
+          return rest;
+        }
+        return prev;
+      });
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const result = validateHabitForm(formState);
+      if (!result.isValid) {
+        setErrors(result.errors);
+        return;
+      }
+      setErrors({});
+      onSubmit(formState);
+    },
+    [formState, onSubmit],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <NameInput
+        value={formState.name}
+        onChange={(value) => updateField('name', value)}
+        error={errors['name']}
+      />
+
+      <FrequencyTypeSelector
+        value={formState.frequencyType}
+        onChange={(value) => updateField('frequencyType', value)}
+      />
+
+      {formState.frequencyType === 'weekly_days' && (
+        <DaySelector
+          selectedDays={formState.weeklyDays}
+          onChange={(days) => updateField('weeklyDays', days)}
+          error={errors['weeklyDays']}
+        />
+      )}
+
+      {formState.frequencyType === 'weekly_count' && (
+        <CountInput
+          value={formState.weeklyCount}
+          onChange={(value) => updateField('weeklyCount', value)}
+          error={errors['weeklyCount']}
+        />
+      )}
+
+      <ColorSelector
+        value={formState.color}
+        onChange={(value) => updateField('color', value)}
+        error={errors['color']}
+      />
+
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        {isSubmitting ? '保存中...' : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/src/ui/components/__tests__/HabitCard.test.tsx
+++ b/src/ui/components/__tests__/HabitCard.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * HabitCard tests - Verifies rendering, navigation link, and archive action.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom/vitest';
+import { HabitCard } from '../HabitCard';
+import type { Habit } from '@/domain/models/habit';
+
+const activeHabit: Habit = {
+  id: 'h1',
+  userId: 'u1',
+  name: '読書する',
+  frequency: { type: 'daily' },
+  color: '#4CAF50',
+  createdAt: '2026-01-01T00:00:00Z',
+  archivedAt: null,
+};
+
+const archivedHabit: Habit = {
+  ...activeHabit,
+  id: 'h2',
+  name: '瞑想する',
+  archivedAt: '2026-02-01T00:00:00Z',
+};
+
+describe('HabitCard', () => {
+  const mockOnArchive = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders habit name and frequency', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('読書する')).toBeInTheDocument();
+    expect(screen.getByText('毎日')).toBeInTheDocument();
+  });
+
+  it('renders edit link pointing to /habits/:id', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/habits/h1');
+  });
+
+  it('shows archive button for active habits', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('アーカイブ')).toBeInTheDocument();
+  });
+
+  it('shows restore button for archived habits', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={archivedHabit} onArchive={mockOnArchive} isArchived={true} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('復元')).toBeInTheDocument();
+  });
+
+  it('calls onArchive when archive button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByText('アーカイブ'));
+    expect(mockOnArchive).toHaveBeenCalledWith('h1');
+  });
+
+  it('applies line-through style for archived habits', () => {
+    render(
+      <MemoryRouter>
+        <HabitCard habit={archivedHabit} onArchive={mockOnArchive} isArchived={true} />
+      </MemoryRouter>,
+    );
+    const name = screen.getByText('瞑想する');
+    expect(name).toHaveClass('line-through');
+  });
+
+  it('displays weekly_days frequency correctly', () => {
+    const weeklyHabit: Habit = {
+      ...activeHabit,
+      frequency: { type: 'weekly_days', days: [1, 3, 5] },
+    };
+    render(
+      <MemoryRouter>
+        <HabitCard habit={weeklyHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('月・水・金')).toBeInTheDocument();
+  });
+
+  it('displays weekly_count frequency correctly', () => {
+    const countHabit: Habit = {
+      ...activeHabit,
+      frequency: { type: 'weekly_count', count: 3 },
+    };
+    render(
+      <MemoryRouter>
+        <HabitCard habit={countHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('週3回')).toBeInTheDocument();
+  });
+
+  it('renders color indicator with correct background color', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+      </MemoryRouter>,
+    );
+    const colorDot = container.querySelector('[aria-hidden="true"]');
+    expect(colorDot).toHaveStyle({ backgroundColor: '#4CAF50' });
+  });
+});

--- a/src/ui/components/__tests__/HabitForm.test.tsx
+++ b/src/ui/components/__tests__/HabitForm.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * HabitForm tests - Verifies form rendering, validation, and submission.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { HabitForm } from '../HabitForm';
+import type { HabitFormState } from '@/domain/models/habitFormValidation';
+import { PRESET_COLORS } from '@/domain/models/habitFormValidation';
+
+describe('HabitForm', () => {
+  const mockOnSubmit = vi.fn();
+
+  function renderForm(props?: Partial<React.ComponentProps<typeof HabitForm>>) {
+    return render(
+      <HabitForm
+        onSubmit={mockOnSubmit}
+        isSubmitting={false}
+        submitLabel="保存"
+        {...props}
+      />,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all form fields', () => {
+    renderForm();
+    expect(screen.getByText('習慣名')).toBeInTheDocument();
+    expect(screen.getByText('頻度')).toBeInTheDocument();
+    expect(screen.getByText('色')).toBeInTheDocument();
+    expect(screen.getByText('保存')).toBeInTheDocument();
+  });
+
+  it('renders frequency type buttons', () => {
+    renderForm();
+    expect(screen.getByText('毎日')).toBeInTheDocument();
+    expect(screen.getByText('特定曜日')).toBeInTheDocument();
+    expect(screen.getByText('週N回')).toBeInTheDocument();
+  });
+
+  it('shows day selector when weekly_days is selected', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('特定曜日'));
+    expect(screen.getByText('曜日を選択')).toBeInTheDocument();
+    expect(screen.getByLabelText('月曜日')).toBeInTheDocument();
+  });
+
+  it('shows count input when weekly_count is selected', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('週N回'));
+    expect(screen.getByText('週の回数')).toBeInTheDocument();
+  });
+
+  it('hides day selector when daily is selected', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('特定曜日'));
+    expect(screen.getByText('曜日を選択')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('毎日'));
+    expect(screen.queryByText('曜日を選択')).not.toBeInTheDocument();
+  });
+
+  it('shows validation error for empty name', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('保存'));
+    expect(screen.getByText('習慣名を入力してください')).toBeInTheDocument();
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for weekly_days without days selected', () => {
+    renderForm();
+    fireEvent.change(screen.getByPlaceholderText('例: 読書する'), {
+      target: { value: '運動' },
+    });
+    fireEvent.click(screen.getByText('特定曜日'));
+    fireEvent.click(screen.getByText('保存'));
+    expect(
+      screen.getByText('曜日を1つ以上選択してください'),
+    ).toBeInTheDocument();
+    expect(mockOnSubmit).not.toHaveBeenCalled();
+  });
+
+  it('calls onSubmit with valid daily form state', () => {
+    renderForm();
+    fireEvent.change(screen.getByPlaceholderText('例: 読書する'), {
+      target: { value: '読書する' },
+    });
+    fireEvent.click(screen.getByText('保存'));
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    const submittedState = mockOnSubmit.mock.calls[0][0] as HabitFormState;
+    expect(submittedState.name).toBe('読書する');
+    expect(submittedState.frequencyType).toBe('daily');
+    expect(submittedState.color).toBe(PRESET_COLORS[0]);
+  });
+
+  it('calls onSubmit with valid weekly_days form state', () => {
+    renderForm();
+    fireEvent.change(screen.getByPlaceholderText('例: 読書する'), {
+      target: { value: 'ジョギング' },
+    });
+    fireEvent.click(screen.getByText('特定曜日'));
+    fireEvent.click(screen.getByLabelText('月曜日'));
+    fireEvent.click(screen.getByLabelText('水曜日'));
+    fireEvent.click(screen.getByText('保存'));
+    expect(mockOnSubmit).toHaveBeenCalledOnce();
+    const submittedState = mockOnSubmit.mock.calls[0][0] as HabitFormState;
+    expect(submittedState.frequencyType).toBe('weekly_days');
+    expect(submittedState.weeklyDays).toEqual([1, 3]);
+  });
+
+  it('pre-fills form with initial state', () => {
+    const initialState: HabitFormState = {
+      name: '瞑想する',
+      frequencyType: 'weekly_count',
+      weeklyDays: [],
+      weeklyCount: 3,
+      color: PRESET_COLORS[2],
+    };
+    renderForm({ initialState });
+    expect(screen.getByDisplayValue('瞑想する')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('3')).toBeInTheDocument();
+  });
+
+  it('disables submit button when isSubmitting is true', () => {
+    renderForm({ isSubmitting: true });
+    expect(screen.getByText('保存中...')).toBeInTheDocument();
+  });
+
+  it('uses custom submitLabel', () => {
+    renderForm({ submitLabel: '更新する' });
+    expect(screen.getByText('更新する')).toBeInTheDocument();
+  });
+
+  it('clears field error when the field value changes', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('保存'));
+    expect(screen.getByText('習慣名を入力してください')).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText('例: 読書する'), {
+      target: { value: 'a' },
+    });
+    expect(
+      screen.queryByText('習慣名を入力してください'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('toggles day selection on and off', () => {
+    renderForm();
+    fireEvent.click(screen.getByText('特定曜日'));
+    const mondayButton = screen.getByLabelText('月曜日');
+    fireEvent.click(mondayButton);
+    expect(mondayButton).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(mondayButton);
+    expect(mondayButton).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders color buttons for all preset colors', () => {
+    renderForm();
+    for (const color of PRESET_COLORS) {
+      expect(screen.getByLabelText(`色: ${color}`)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/ui/pages/HabitDetailPage.tsx
+++ b/src/ui/pages/HabitDetailPage.tsx
@@ -1,20 +1,171 @@
 /**
- * HabitDetailPage - Placeholder for the habit edit/detail screen.
- * Full implementation will be done in a separate issue.
+ * HabitDetailPage - Page for editing an existing habit.
+ *
+ * Loads existing habit data by ID, pre-fills the form, and updates on save.
  */
 
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState, useCallback, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { HabitForm } from '@/ui/components/HabitForm';
+import { useHabits } from '@/hooks/useHabits';
+import { useAuthContext } from '@/hooks/useAuthContext';
+import { useRepositories } from '@/hooks/useRepositories';
+import {
+  habitToFormState,
+  toCreateHabitInput,
+} from '@/domain/models/habitFormValidation';
+import type { HabitFormState } from '@/domain/models/habitFormValidation';
+import type { Habit } from '@/domain/models/habit';
 
 export function HabitDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { user } = useAuthContext();
+  const { habitRepository } = useRepositories();
+  const { updateHabit, archiveHabit } = useHabits(habitRepository);
+
+  const [habit, setHabit] = useState<Habit | null>(null);
+  const [isLoadingHabit, setIsLoadingHabit] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    let cancelled = false;
+
+    async function loadHabit() {
+      setIsLoadingHabit(true);
+      setLoadError(null);
+      try {
+        const found = await habitRepository.findById(id!);
+        if (cancelled) {
+          return;
+        }
+        if (!found) {
+          setLoadError('習慣が見つかりません');
+        } else {
+          setHabit(found);
+        }
+      } catch (error: unknown) {
+        if (cancelled) {
+          return;
+        }
+        const message =
+          error instanceof Error
+            ? error.message
+            : '習慣の読み込みに失敗しました';
+        setLoadError(message);
+      } finally {
+        if (!cancelled) {
+          setIsLoadingHabit(false);
+        }
+      }
+    }
+
+    void loadHabit();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, habitRepository]);
+
+  const handleSubmit = useCallback(
+    async (formState: HabitFormState) => {
+      if (!user || !id) {
+        return;
+      }
+      setIsSubmitting(true);
+      setSubmitError(null);
+      try {
+        const input = toCreateHabitInput(formState, user.id);
+        await updateHabit(id, input);
+        navigate('/habits');
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : '習慣の更新に失敗しました';
+        setSubmitError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [user, id, updateHabit, navigate],
+  );
+
+  const handleArchive = useCallback(async () => {
+    if (!id) {
+      return;
+    }
+    try {
+      await archiveHabit(id);
+      navigate('/habits');
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '習慣のアーカイブに失敗しました';
+      setSubmitError(message);
+    }
+  }, [id, archiveHabit, navigate]);
+
+  if (isLoadingHabit) {
+    return (
+      <div className="mx-auto max-w-lg p-6">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto max-w-lg p-6">
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {loadError}
+        </div>
+        <Button variant="outline" onClick={() => navigate('/habits')}>
+          一覧に戻る
+        </Button>
+      </div>
+    );
+  }
+
+  if (!habit) {
+    return null;
+  }
 
   return (
-    <div className="p-8">
-      <h1 className="mb-4 text-2xl font-bold text-foreground">習慣の編集</h1>
-      <p className="text-muted-foreground">
-        習慣 (ID: {id}) の編集フォームがここに表示されます。
-      </p>
+    <div className="mx-auto max-w-lg p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-foreground">習慣の編集</h1>
+        {habit.archivedAt === null && (
+          <Button variant="destructive" size="sm" onClick={handleArchive}>
+            アーカイブ
+          </Button>
+        )}
+      </div>
+
+      {submitError && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {submitError}
+        </div>
+      )}
+
+      <HabitForm
+        initialState={habitToFormState(habit)}
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        submitLabel="更新する"
+      />
     </div>
   );
 }

--- a/src/ui/pages/HabitsPage.tsx
+++ b/src/ui/pages/HabitsPage.tsx
@@ -1,24 +1,85 @@
 /**
- * HabitsPage - Placeholder for the habits list screen.
- * Full implementation will be done in a separate issue.
+ * HabitsPage - Displays all habits with archive toggle and navigation to add/edit.
+ *
+ * Uses useHabitList hook for habit management including archived habits.
  */
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
+import { HabitCard } from '@/ui/components/HabitCard';
+import { useHabitList } from '@/hooks/useHabitList';
+import { useRepositories } from '@/hooks/useRepositories';
 
 export function HabitsPage() {
   const navigate = useNavigate();
+  const { habitRepository } = useRepositories();
+  const {
+    displayHabits,
+    showArchived,
+    toggleShowArchived,
+    isLoading,
+    error,
+    archiveHabit,
+  } = useHabitList(habitRepository);
 
   return (
-    <div className="p-8">
+    <div className="mx-auto max-w-2xl p-6">
       <div className="mb-6 flex items-center justify-between">
         <h1 className="text-2xl font-bold text-foreground">習慣一覧</h1>
-        <Button onClick={() => navigate('/habits/new')}>新しい習慣</Button>
+        <Button onClick={() => navigate('/habits/new')}>+ 新しい習慣</Button>
       </div>
-      <p className="text-muted-foreground">
-        習慣の一覧がここに表示されます。
-      </p>
+
+      <div className="mb-4 flex items-center gap-2">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={showArchived}
+            onChange={toggleShowArchived}
+            className="h-4 w-4 rounded border-input"
+          />
+          アーカイブ済みを表示
+        </label>
+      </div>
+
+      {error && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex justify-center py-8">
+          <p className="text-muted-foreground">読み込み中...</p>
+        </div>
+      )}
+
+      {!isLoading && displayHabits.length === 0 && (
+        <div className="flex flex-col items-center gap-2 py-12 text-center">
+          <p className="text-muted-foreground">
+            まだ習慣がありません
+          </p>
+          <Button variant="outline" onClick={() => navigate('/habits/new')}>
+            最初の習慣を追加する
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && displayHabits.length > 0 && (
+        <div className="space-y-2">
+          {displayHabits.map((habit) => (
+            <HabitCard
+              key={habit.id}
+              habit={habit}
+              onArchive={archiveHabit}
+              isArchived={habit.archivedAt !== null}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/ui/pages/NewHabitPage.tsx
+++ b/src/ui/pages/NewHabitPage.tsx
@@ -1,19 +1,68 @@
 /**
- * NewHabitPage - Placeholder for the new habit creation screen.
- * Full implementation will be done in a separate issue.
+ * NewHabitPage - Page for creating a new habit.
+ *
+ * Uses the shared HabitForm component and navigates back to /habits on success.
  */
 
-import React from 'react';
+import React, { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { HabitForm } from '@/ui/components/HabitForm';
+import { useHabits } from '@/hooks/useHabits';
+import { useAuthContext } from '@/hooks/useAuthContext';
+import { useRepositories } from '@/hooks/useRepositories';
+import { toCreateHabitInput } from '@/domain/models/habitFormValidation';
+import type { HabitFormState } from '@/domain/models/habitFormValidation';
 
 export function NewHabitPage() {
+  const navigate = useNavigate();
+  const { user } = useAuthContext();
+  const { habitRepository } = useRepositories();
+  const { createHabit } = useHabits(habitRepository);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const handleSubmit = useCallback(
+    async (formState: HabitFormState) => {
+      if (!user) {
+        return;
+      }
+      setIsSubmitting(true);
+      setSubmitError(null);
+      try {
+        const input = toCreateHabitInput(formState, user.id);
+        await createHabit(input);
+        navigate('/habits');
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : '習慣の作成に失敗しました';
+        setSubmitError(message);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [user, createHabit, navigate],
+  );
+
   return (
-    <div className="p-8">
-      <h1 className="mb-4 text-2xl font-bold text-foreground">
+    <div className="mx-auto max-w-lg p-6">
+      <h1 className="mb-6 text-2xl font-bold text-foreground">
         新しい習慣を追加
       </h1>
-      <p className="text-muted-foreground">
-        習慣の追加フォームがここに表示されます。
-      </p>
+
+      {submitError && (
+        <div
+          className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          role="alert"
+        >
+          {submitError}
+        </div>
+      )}
+
+      <HabitForm
+        onSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+        submitLabel="追加する"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

closes #39

- **HabitsPage**: 全習慣の一覧表示、アーカイブ済み表示切り替え、新規追加ボタン
- **NewHabitPage**: HabitFormコンポーネントを使った新規習慣作成画面
- **HabitDetailPage**: 既存習慣の編集・アーカイブ機能（IDによるロード、プリフィル）
- **HabitForm**: 共通フォームコンポーネント（習慣名、頻度タイプ、曜日選択、回数入力、色選択）
- **HabitCard**: 習慣カード表示（色、頻度表示、編集リンク、アーカイブボタン）
- 既存のZodバリデーション（habitFormValidation.ts）を統合
- フィールド単位のバリデーションエラー表示
- ローディング・エラー状態のハンドリング

## 技術的な詳細

- `useHabitList` フックで一覧管理（アクティブ＋アーカイブ）
- `useHabits` フックでCRUD操作
- `useAuthContext()` でuserId取得、`useRepositories()` でリポジトリ取得
- `habitToFormState()` / `toCreateHabitInput()` でドメインモデル変換
- `formatFrequency()` で頻度の日本語表示
- イミュータブルな状態更新パターン

## テスト計画

- [x] HabitFormコンポーネントテスト（15件）
  - フォームフィールドの表示
  - 頻度タイプ切り替えによるUI変化
  - バリデーションエラー表示
  - 有効な入力での送信
  - 初期値のプリフィル
  - フィールド変更時のエラークリア
- [x] HabitCardコンポーネントテスト（9件）
  - 習慣名・頻度の表示
  - 編集リンク（/habits/:id）
  - アーカイブ/復元ボタン
  - アーカイブ済みスタイル（line-through）
  - 色表示
- [x] 既存テスト全316件パス
- [x] TypeScript型チェックパス