### PR TITLE
fix: iOS SafariでCheckboxが動作しない問題をネイティブinputで修正

### DIFF
--- a/src/components/ui/__tests__/Checkbox.test.tsx
+++ b/src/components/ui/__tests__/Checkbox.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Checkbox component tests - Verifies rendering, check/uncheck behavior,
+ * disabled state, and accessibility attributes.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { Checkbox } from '../checkbox';
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox aria-label="test checkbox" />);
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    expect(input).not.toBeChecked();
+  });
+
+  it('renders checked when checked prop is true', () => {
+    render(<Checkbox checked aria-label="test checkbox" />);
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    expect(input).toBeChecked();
+  });
+
+  it('shows checkmark SVG only when checked', () => {
+    const { container, rerender } = render(
+      <Checkbox checked={false} aria-label="test checkbox" />,
+    );
+    expect(container.querySelector('svg')).toBeNull();
+
+    rerender(<Checkbox checked aria-label="test checkbox" />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('calls onCheckedChange with true when clicking unchecked checkbox', () => {
+    const handleChange = vi.fn();
+    render(
+      <Checkbox
+        checked={false}
+        onCheckedChange={handleChange}
+        aria-label="test checkbox"
+      />,
+    );
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    fireEvent.click(input);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onCheckedChange with false when clicking checked checkbox', () => {
+    const handleChange = vi.fn();
+    render(
+      <Checkbox
+        checked
+        onCheckedChange={handleChange}
+        aria-label="test checkbox"
+      />,
+    );
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    fireEvent.click(input);
+    expect(handleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not call onCheckedChange when disabled', () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <Checkbox
+        checked={false}
+        onCheckedChange={handleChange}
+        disabled
+        aria-label="test checkbox"
+      />,
+    );
+    // Click on the label wrapper (simulates real user click)
+    const label = container.querySelector('label');
+    if (label) {
+      fireEvent.click(label);
+    }
+    // In jsdom, disabled inputs still fire events via fireEvent,
+    // so we verify the input is actually disabled instead
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    expect(input).toBeDisabled();
+  });
+
+  it('applies disabled attribute to the input', () => {
+    render(<Checkbox disabled aria-label="test checkbox" />);
+    const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+    expect(input).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <Checkbox className="custom-class" aria-label="test checkbox" />,
+    );
+    const label = container.querySelector('label');
+    expect(label?.className).toContain('custom-class');
+  });
+
+  it('renders without onCheckedChange without error', () => {
+    expect(() => {
+      render(<Checkbox checked={false} aria-label="test checkbox" />);
+      const input = screen.getByRole('checkbox', { name: 'test checkbox' });
+      fireEvent.click(input);
+    }).not.toThrow();
+  });
+});

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,9 +1,10 @@
 /**
- * Checkbox component built with @base-ui/react Checkbox primitive.
+ * Checkbox component using native <input type="checkbox">.
+ * Replaces @base-ui/react Checkbox to fix iOS Safari event propagation issues.
  * Styled with Tailwind CSS to match the design system.
  */
 
-import { Checkbox as CheckboxPrimitive } from '@base-ui/react/checkbox';
+import { useCallback } from 'react';
 import { cn } from '@/lib/utils';
 
 type CheckboxProps = {
@@ -21,35 +22,55 @@ function Checkbox({
   'aria-label': ariaLabel,
   disabled = false,
 }: CheckboxProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onCheckedChange?.(e.target.checked);
+    },
+    [onCheckedChange],
+  );
+
   return (
-    <CheckboxPrimitive.Root
-      checked={checked}
-      onCheckedChange={onCheckedChange}
-      disabled={disabled}
-      aria-label={ariaLabel}
+    <label
       className={cn(
-        'flex size-5 shrink-0 items-center justify-center rounded-md border-2 border-muted-foreground/40 transition-colors',
-        'hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        'data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground',
-        'disabled:cursor-not-allowed disabled:opacity-50',
+        'relative inline-flex size-5 shrink-0 items-center justify-center',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         className,
       )}
     >
-      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="3"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          className="size-3.5"
-        >
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
-      </CheckboxPrimitive.Indicator>
-    </CheckboxPrimitive.Root>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={handleChange}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className="sr-only"
+      />
+      <span
+        className={cn(
+          'flex size-5 items-center justify-center rounded-md border-2 transition-colors',
+          checked
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-muted-foreground/40 hover:border-primary',
+          'focus-within:outline-none focus-within:ring-2 focus-within:ring-ring',
+        )}
+      >
+        {checked && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="size-3.5"
+            aria-hidden="true"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        )}
+      </span>
+    </label>
   );
 }
 


### PR DESCRIPTION
## Summary

- `@base-ui/react/checkbox` の内部 `dispatchEvent` による合成イベント伝播が iOS Safari で正しく動作しない問題を修正
- ネイティブ `<input type="checkbox">` をベースにした実装に差し替え（sr-only + カスタムスタイル span パターン）
- 既存の Props API（`checked`, `onCheckedChange`, `className`, `aria-label`, `disabled`）を維持し、利用側の変更は不要

Closes #61

## Test plan

- [x] Checkbox コンポーネントのユニットテスト 9 件追加・全パス
- [x] 既存テスト 345 件が全てパスすることを確認（合計 354 件）
- [x] TypeScript 型チェックエラーなし
- [ ] iOS Safari 実機でチェックボックスの表示・トグル動作を確認
- [ ] デスクトップブラウザで見た目が従来と同等であることを確認