### PR TITLE
fix: useStreakの無限ループによるブラウザ重負荷を修正

### DIFF
--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -54,6 +54,7 @@ export function useStreak(
 ): UseStreakResult {
   const [state, setState] = useState<StreakState>(INITIAL_STATE);
   const cacheRef = useRef<Map<string, readonly Completion[]>>(new Map());
+  const fetchingRef = useRef<Set<string>>(new Set());
 
   const habitsMap = useMemo(() => {
     const map = new Map<string, Habit>();
@@ -86,6 +87,10 @@ export function useStreak(
       if (cached !== undefined) {
         return cached;
       }
+      if (fetchingRef.current.has(habitId)) {
+        return [];
+      }
+      fetchingRef.current.add(habitId);
       setState((prev) => ({ ...prev, loading: true }));
       try {
         return await fetchCompletions(habitId);
@@ -96,6 +101,8 @@ export function useStreak(
           error: extractErrorMessage(err),
         }));
         return [];
+      } finally {
+        fetchingRef.current.delete(habitId);
       }
     },
     [fetchCompletions],


### PR DESCRIPTION
## Summary
- `useStreak`の`ensureCompletions`による無限ループを修正
- `fetchingRef`で同一habitIdへの重複fetchを防止

## 原因
`getStreak`がレンダリング中に`ensureCompletions`を fire-and-forget で呼び出し:
1. `ensureCompletions` → `setState({loading: true})` → 新オブジェクト生成 → 再レンダリング
2. 再レンダリング → `getStreak` → キャッシュなし（fetch未完了） → `ensureCompletions` 再呼出し
3. 無限ループ → `ERR_INSUFFICIENT_RESOURCES`

## 修正
`fetchingRef`（`Set<string>`）でfetch中のhabitIdを追跡。同じhabitIdへの重複fetchをスキップし、fetch完了時に`finally`でクリア。

## Test plan
- [x] ユニットテスト349件全パス
- [x] E2Eテスト18件全パス
- [ ] ブラウザで`ERR_INSUFFICIENT_RESOURCES`が発生しないことを確認
- [ ] iPhoneのSafariでの動作確認