### PR TITLE
fix: 習慣一覧からアーカイブボタンを削除

### DIFF
--- a/src/ui/components/HabitCard.tsx
+++ b/src/ui/components/HabitCard.tsx
@@ -37,18 +37,16 @@ export function HabitCard({ habit, onArchive, isArchived }: HabitCardProps) {
         </span>
       </Link>
 
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={() => onArchive(habit.id)}
-        aria-label={
-          isArchived
-            ? `${habit.name}をアーカイブ解除`
-            : `${habit.name}をアーカイブ`
-        }
-      >
-        {isArchived ? '復元' : 'アーカイブ'}
-      </Button>
+      {isArchived && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onArchive(habit.id)}
+          aria-label={`${habit.name}をアーカイブ解除`}
+        >
+          復元
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/ui/components/__tests__/HabitCard.test.tsx
+++ b/src/ui/components/__tests__/HabitCard.test.tsx
@@ -59,13 +59,14 @@ describe('HabitCard', () => {
     expect(link).toHaveAttribute('href', '/habits/h1');
   });
 
-  it('shows archive button for active habits', () => {
+  it('does not show archive button for active habits', () => {
     render(
       <MemoryRouter>
         <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
       </MemoryRouter>,
     );
-    expect(screen.getByText('アーカイブ')).toBeInTheDocument();
+    expect(screen.queryByText('アーカイブ')).not.toBeInTheDocument();
+    expect(screen.queryByText('復元')).not.toBeInTheDocument();
   });
 
   it('shows restore button for archived habits', () => {
@@ -77,14 +78,14 @@ describe('HabitCard', () => {
     expect(screen.getByText('復元')).toBeInTheDocument();
   });
 
-  it('calls onArchive when archive button is clicked', () => {
+  it('calls onArchive when restore button is clicked', () => {
     render(
       <MemoryRouter>
-        <HabitCard habit={activeHabit} onArchive={mockOnArchive} isArchived={false} />
+        <HabitCard habit={archivedHabit} onArchive={mockOnArchive} isArchived={true} />
       </MemoryRouter>,
     );
-    fireEvent.click(screen.getByText('アーカイブ'));
-    expect(mockOnArchive).toHaveBeenCalledWith('h1');
+    fireEvent.click(screen.getByText('復元'));
+    expect(mockOnArchive).toHaveBeenCalledWith('h2');
   });
 
   it('applies line-through style for archived habits', () => {


### PR DESCRIPTION
## Summary

習慣一覧のカードからアーカイブボタンを削除。誤タップ防止のため。
アーカイブは編集画面（#78で移動済み）から行う。
アーカイブ済み習慣の「復元」ボタンは残す。

## Test plan

- [x] ユニットテスト全パス (408/408)
- [x] ビルド成功