### PR TITLE
fix: カレンダーフィルターUI修正

### DIFF
--- a/src/ui/components/HabitFilter.tsx
+++ b/src/ui/components/HabitFilter.tsx
@@ -34,14 +34,14 @@ function FilterButton({
       type="button"
       className={cn(
         'rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
-        isSelected
-          ? 'text-white shadow-sm'
-          : 'bg-muted text-muted-foreground hover:bg-muted/80',
+        isSelected && !color && 'bg-primary text-primary-foreground shadow-sm',
+        isSelected && color && 'text-white shadow-sm',
+        !isSelected && 'bg-muted text-muted-foreground hover:bg-muted/80',
         isArchived && !isSelected && 'opacity-60',
       )}
       style={
-        isSelected
-          ? { backgroundColor: color ?? 'hsl(var(--primary))' }
+        isSelected && color
+          ? { backgroundColor: color }
           : undefined
       }
       onClick={onClick}

--- a/src/ui/pages/CalendarPage.tsx
+++ b/src/ui/pages/CalendarPage.tsx
@@ -110,22 +110,6 @@ export function CalendarPage() {
     return habit?.color;
   }, [filter, allHabits]);
 
-  if (isLoading) {
-    return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-6">
-        <LoadingState />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="mx-auto w-full max-w-2xl px-4 py-6">
-        <ErrorState message={error} />
-      </div>
-    );
-  }
-
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-6">
       <header className="mb-6">
@@ -140,14 +124,20 @@ export function CalendarPage() {
         onNext={goToNextMonth}
       />
 
-      <div className="mb-6">
-        <HeatmapCalendar
-          calendarGrid={calendarGrid}
-          achievements={achievements}
-          filterMode={filter.mode === 'all' ? 'all' : 'habit'}
-          selectedHabitColor={selectedHabitColor}
-        />
-      </div>
+      {error && <ErrorState message={error} />}
+
+      {isLoading ? (
+        <LoadingState />
+      ) : (
+        <div className="mb-6">
+          <HeatmapCalendar
+            calendarGrid={calendarGrid}
+            achievements={achievements}
+            filterMode={filter.mode === 'all' ? 'all' : 'habit'}
+            selectedHabitColor={selectedHabitColor}
+          />
+        </div>
+      )}
 
       <div>
         <h3 className="mb-2 text-sm font-medium text-muted-foreground">


### PR DESCRIPTION
## Summary

- 「すべて」ボタンが黒背景に黒文字で見づらい問題を修正（bg-primary/text-primary-foregroundに変更）
- フィルター切り替え時にローディング中にフィルターUIが消える問題を修正（月ナビ・フィルターは常時表示、カレンダー部分のみローディング表示）

## Test plan

- [x] ユニットテスト全パス (457/457)
- [x] ビルド成功