### PR TITLE
fix: ダークテーマのCSS値をoklch形式に変換

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,75 +6,76 @@
 @custom-variant dark (&:is(.dark *));
 
 /* Dark theme inspired by sample design
-   bg: #0e0e12, surface: #16161e, accent: #a78bfa (purple) */
+   bg: #0e0e12, surface: #16161e, accent: #a78bfa (purple)
+   All values in oklch for Tailwind CSS 4 compatibility */
 :root {
-    --background: #0e0e12;
-    --foreground: #e8e8f0;
-    --card: #16161e;
-    --card-foreground: #e8e8f0;
-    --popover: #1e1e2a;
-    --popover-foreground: #e8e8f0;
-    --primary: #a78bfa;
-    --primary-foreground: #ffffff;
-    --secondary: #1e1e2a;
-    --secondary-foreground: #e8e8f0;
-    --muted: #1e1e2a;
-    --muted-foreground: #6b6b80;
-    --accent: #1e1e2a;
-    --accent-foreground: #e8e8f0;
-    --destructive: #f87171;
-    --border: rgba(255, 255, 255, 0.07);
-    --input: rgba(255, 255, 255, 0.1);
-    --ring: #a78bfa;
-    --chart-1: #a78bfa;
-    --chart-2: #f472b6;
-    --chart-3: #34d399;
-    --chart-4: #60a5fa;
-    --chart-5: #fbbf24;
+    --background: oklch(0.09 0.005 285);
+    --foreground: oklch(0.93 0.01 285);
+    --card: oklch(0.14 0.005 285);
+    --card-foreground: oklch(0.93 0.01 285);
+    --popover: oklch(0.17 0.01 285);
+    --popover-foreground: oklch(0.93 0.01 285);
+    --primary: oklch(0.65 0.15 285);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.17 0.01 285);
+    --secondary-foreground: oklch(0.93 0.01 285);
+    --muted: oklch(0.17 0.01 285);
+    --muted-foreground: oklch(0.50 0.01 285);
+    --accent: oklch(0.17 0.01 285);
+    --accent-foreground: oklch(0.93 0.01 285);
+    --destructive: oklch(0.65 0.2 25);
+    --border: oklch(1 0 0 / 7%);
+    --input: oklch(1 0 0 / 10%);
+    --ring: oklch(0.65 0.15 285);
+    --chart-1: oklch(0.65 0.15 285);
+    --chart-2: oklch(0.7 0.18 350);
+    --chart-3: oklch(0.75 0.15 165);
+    --chart-4: oklch(0.7 0.12 250);
+    --chart-5: oklch(0.8 0.15 85);
     --radius: 0.75rem;
-    --sidebar: #16161e;
-    --sidebar-foreground: #e8e8f0;
-    --sidebar-primary: #a78bfa;
-    --sidebar-primary-foreground: #ffffff;
-    --sidebar-accent: #1e1e2a;
-    --sidebar-accent-foreground: #e8e8f0;
-    --sidebar-border: rgba(255, 255, 255, 0.07);
-    --sidebar-ring: #a78bfa;
+    --sidebar: oklch(0.14 0.005 285);
+    --sidebar-foreground: oklch(0.93 0.01 285);
+    --sidebar-primary: oklch(0.65 0.15 285);
+    --sidebar-primary-foreground: oklch(1 0 0);
+    --sidebar-accent: oklch(0.17 0.01 285);
+    --sidebar-accent-foreground: oklch(0.93 0.01 285);
+    --sidebar-border: oklch(1 0 0 / 7%);
+    --sidebar-ring: oklch(0.65 0.15 285);
 }
 
 /* Keep dark variant identical since we are always dark */
 .dark {
-    --background: #0e0e12;
-    --foreground: #e8e8f0;
-    --card: #16161e;
-    --card-foreground: #e8e8f0;
-    --popover: #1e1e2a;
-    --popover-foreground: #e8e8f0;
-    --primary: #a78bfa;
-    --primary-foreground: #ffffff;
-    --secondary: #1e1e2a;
-    --secondary-foreground: #e8e8f0;
-    --muted: #1e1e2a;
-    --muted-foreground: #6b6b80;
-    --accent: #1e1e2a;
-    --accent-foreground: #e8e8f0;
-    --destructive: #f87171;
-    --border: rgba(255, 255, 255, 0.07);
-    --input: rgba(255, 255, 255, 0.1);
-    --ring: #a78bfa;
-    --chart-1: #a78bfa;
-    --chart-2: #f472b6;
-    --chart-3: #34d399;
-    --chart-4: #60a5fa;
-    --chart-5: #fbbf24;
-    --sidebar: #16161e;
-    --sidebar-foreground: #e8e8f0;
-    --sidebar-primary: #a78bfa;
-    --sidebar-primary-foreground: #ffffff;
-    --sidebar-accent: #1e1e2a;
-    --sidebar-accent-foreground: #e8e8f0;
-    --sidebar-border: rgba(255, 255, 255, 0.07);
-    --sidebar-ring: #a78bfa;
+    --background: oklch(0.09 0.005 285);
+    --foreground: oklch(0.93 0.01 285);
+    --card: oklch(0.14 0.005 285);
+    --card-foreground: oklch(0.93 0.01 285);
+    --popover: oklch(0.17 0.01 285);
+    --popover-foreground: oklch(0.93 0.01 285);
+    --primary: oklch(0.65 0.15 285);
+    --primary-foreground: oklch(1 0 0);
+    --secondary: oklch(0.17 0.01 285);
+    --secondary-foreground: oklch(0.93 0.01 285);
+    --muted: oklch(0.17 0.01 285);
+    --muted-foreground: oklch(0.50 0.01 285);
+    --accent: oklch(0.17 0.01 285);
+    --accent-foreground: oklch(0.93 0.01 285);
+    --destructive: oklch(0.65 0.2 25);
+    --border: oklch(1 0 0 / 7%);
+    --input: oklch(1 0 0 / 10%);
+    --ring: oklch(0.65 0.15 285);
+    --chart-1: oklch(0.65 0.15 285);
+    --chart-2: oklch(0.7 0.18 350);
+    --chart-3: oklch(0.75 0.15 165);
+    --chart-4: oklch(0.7 0.12 250);
+    --chart-5: oklch(0.8 0.15 85);
+    --sidebar: oklch(0.14 0.005 285);
+    --sidebar-foreground: oklch(0.93 0.01 285);
+    --sidebar-primary: oklch(0.65 0.15 285);
+    --sidebar-primary-foreground: oklch(1 0 0);
+    --sidebar-accent: oklch(0.17 0.01 285);
+    --sidebar-accent-foreground: oklch(0.93 0.01 285);
+    --sidebar-border: oklch(1 0 0 / 7%);
+    --sidebar-ring: oklch(0.65 0.15 285);
 }
 
 @theme inline {


### PR DESCRIPTION
Tailwind CSS 4互換のためhex/rgba値をoklch形式に変換