### PR TITLE
fix: ダークテーマでのカードスタイル修正

### DIFF
--- a/src/ui/components/HabitCard.tsx
+++ b/src/ui/components/HabitCard.tsx
@@ -16,7 +16,7 @@ type HabitCardProps = {
 
 export function HabitCard({ habit, onRestore, isArchived }: HabitCardProps) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 shadow-sm transition-colors hover:bg-muted/30">
+    <div className="flex items-center gap-3 rounded-2xl border border-border bg-card p-4 shadow-sm transition-all hover:border-primary/20 hover:translate-x-1">
       <div
         className="h-4 w-4 shrink-0 rounded-full"
         style={{ backgroundColor: habit.color }}

--- a/src/ui/components/ReminderSection.tsx
+++ b/src/ui/components/ReminderSection.tsx
@@ -53,7 +53,7 @@ export function ReminderSection({
           }`}
         >
           <span
-            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+            className={`inline-block h-4 w-4 transform rounded-full bg-foreground transition-transform ${
               enabled ? 'translate-x-6' : 'translate-x-1'
             }`}
           />

--- a/src/ui/components/TodayHabitCard.tsx
+++ b/src/ui/components/TodayHabitCard.tsx
@@ -29,10 +29,10 @@ export function TodayHabitCard({
 }: TodayHabitCardProps) {
   return (
     <div
-      className={`flex items-center gap-3 rounded-lg border p-4 shadow-sm transition-colors ${
+      className={`flex items-center gap-3 rounded-2xl border p-4 shadow-sm transition-all ${
         isCompleted
-          ? 'border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950'
-          : 'border-border bg-card'
+          ? 'border-emerald-500/20 bg-emerald-500/5'
+          : 'border-border bg-card hover:border-primary/20'
       }`}
     >
       <div
@@ -58,8 +58,8 @@ export function TodayHabitCard({
 
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {streak.current > 0 && (
-            <span className="font-medium text-orange-500">
-              {streak.current}日連続
+            <span className="font-medium text-primary">
+              🔥 {streak.current}日連続
             </span>
           )}
           {habit.frequency.type === 'weekly_count' && (


### PR DESCRIPTION
## Summary

ダークテーマで習慣完了時のカードが白く浮く問題を修正。

- TodayHabitCard: `bg-green-50` → `bg-emerald-500/5`（微かな緑のグロー）
- 角丸を `rounded-2xl` に統一（サンプルデザイン準拠）
- ホバー時のボーダーをアクセントカラーに
- ストリーク色を `text-primary` に統一
- ReminderSectionトグルの `bg-white` → `bg-foreground`