### PR TITLE
fix: 絵文字削除とTodayPageのリマインダー時刻非表示

### DIFF
--- a/src/ui/components/HabitCard.tsx
+++ b/src/ui/components/HabitCard.tsx
@@ -37,7 +37,7 @@ export function HabitCard({ habit, onRestore, isArchived }: HabitCardProps) {
           {formatFrequency(habit.frequency)}
           {habit.reminderTime && (
             <span className="ml-1.5">
-              🔔 {utcToLocalTime(habit.reminderTime.substring(0, 5), getBrowserTimezoneOffset())}
+              通知 {utcToLocalTime(habit.reminderTime.substring(0, 5), getBrowserTimezoneOffset())}
             </span>
           )}
         </span>

--- a/src/ui/components/TodayHabitCard.tsx
+++ b/src/ui/components/TodayHabitCard.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { Habit } from '@/domain/models/habit';
 import type { Streak } from '@/domain/models/streak';
-import { utcToLocalTime, getBrowserTimezoneOffset } from '@/lib/reminderTime';
 
 type WeeklyProgress = {
   readonly done: number;
@@ -60,17 +59,12 @@ export function TodayHabitCard({
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           {streak.current > 0 && (
             <span className="font-medium text-primary">
-              🔥 {streak.current}日連続
+              {streak.current}日連続
             </span>
           )}
           {habit.frequency.type === 'weekly_count' && (
             <span>
               今週 {weeklyProgress.done}/{weeklyProgress.target}
-            </span>
-          )}
-          {habit.reminderTime && (
-            <span>
-              🔔 {utcToLocalTime(habit.reminderTime.substring(0, 5), getBrowserTimezoneOffset())}
             </span>
           )}
         </div>

--- a/src/ui/components/__tests__/HabitCard.test.tsx
+++ b/src/ui/components/__tests__/HabitCard.test.tsx
@@ -139,7 +139,7 @@ describe('HabitCard', () => {
         <HabitCard habit={activeHabit} isArchived={false} />
       </MemoryRouter>,
     );
-    expect(screen.queryByText(/🔔/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/通知/)).not.toBeInTheDocument();
   });
 
   it('shows reminder time when reminderTime is set', () => {
@@ -152,6 +152,6 @@ describe('HabitCard', () => {
         <HabitCard habit={habitWithReminder} isArchived={false} />
       </MemoryRouter>,
     );
-    expect(screen.getByText(/🔔/)).toBeInTheDocument();
+    expect(screen.getByText(/通知/)).toBeInTheDocument();
   });
 });

--- a/src/ui/components/__tests__/TodayHabitCard.test.tsx
+++ b/src/ui/components/__tests__/TodayHabitCard.test.tsx
@@ -28,14 +28,14 @@ const defaultProps = {
 };
 
 describe('TodayHabitCard', () => {
-  it('does not show reminder time when reminderTime is null', () => {
+  it('renders habit name', () => {
     render(
       <TodayHabitCard habit={baseHabit} {...defaultProps} />,
     );
-    expect(screen.queryByText(/🔔/)).not.toBeInTheDocument();
+    expect(screen.getByText('読書する')).toBeInTheDocument();
   });
 
-  it('shows reminder time when reminderTime is set', () => {
+  it('does not show reminder time even when set', () => {
     const habitWithReminder: Habit = {
       ...baseHabit,
       reminderTime: '09:00:00',
@@ -43,6 +43,6 @@ describe('TodayHabitCard', () => {
     render(
       <TodayHabitCard habit={habitWithReminder} {...defaultProps} />,
     );
-    expect(screen.getByText(/🔔/)).toBeInTheDocument();
+    expect(screen.queryByText(/通知/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- HabitCard: 🔔 → テキスト「通知」に変更
- TodayHabitCard: 🔥 絵文字を削除、リマインダー時刻表示を削除
- テストを更新