### PR TITLE
fix: TodayPageにリマインダー時刻表示を復元

### DIFF
--- a/src/ui/components/TodayHabitCard.tsx
+++ b/src/ui/components/TodayHabitCard.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import type { Habit } from '@/domain/models/habit';
 import type { Streak } from '@/domain/models/streak';
+import { utcToLocalTime, getBrowserTimezoneOffset } from '@/lib/reminderTime';
 
 type WeeklyProgress = {
   readonly done: number;
@@ -65,6 +66,11 @@ export function TodayHabitCard({
           {habit.frequency.type === 'weekly_count' && (
             <span>
               今週 {weeklyProgress.done}/{weeklyProgress.target}
+            </span>
+          )}
+          {habit.reminderTime && (
+            <span>
+              通知 {utcToLocalTime(habit.reminderTime.substring(0, 5), getBrowserTimezoneOffset())}
             </span>
           )}
         </div>

--- a/src/ui/components/__tests__/TodayHabitCard.test.tsx
+++ b/src/ui/components/__tests__/TodayHabitCard.test.tsx
@@ -35,7 +35,14 @@ describe('TodayHabitCard', () => {
     expect(screen.getByText('読書する')).toBeInTheDocument();
   });
 
-  it('does not show reminder time even when set', () => {
+  it('does not show reminder time when reminderTime is null', () => {
+    render(
+      <TodayHabitCard habit={baseHabit} {...defaultProps} />,
+    );
+    expect(screen.queryByText(/通知/)).not.toBeInTheDocument();
+  });
+
+  it('shows reminder time when reminderTime is set', () => {
     const habitWithReminder: Habit = {
       ...baseHabit,
       reminderTime: '09:00:00',
@@ -43,6 +50,6 @@ describe('TodayHabitCard', () => {
     render(
       <TodayHabitCard habit={habitWithReminder} {...defaultProps} />,
     );
-    expect(screen.queryByText(/通知/)).not.toBeInTheDocument();
+    expect(screen.getByText(/通知/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
TodayHabitCardにリマインダー時刻表示を復元。絵文字なし「通知 HH:MM」形式。