### PR TITLE
fix: タスク日付入力のUX改善

### DIFF
--- a/src/ui/components/TaskCard.tsx
+++ b/src/ui/components/TaskCard.tsx
@@ -121,13 +121,30 @@ export function TaskCard({
             aria-label="タスク名"
           />
 
-          <input
-            type="date"
-            value={editDueDate}
-            onChange={(e) => setEditDueDate(e.target.value)}
-            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
-            aria-label="期限日"
-          />
+          <div>
+            <label className="mb-1 block text-xs text-muted-foreground">
+              日付（任意）
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="date"
+                value={editDueDate}
+                onChange={(e) => setEditDueDate(e.target.value)}
+                className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+                aria-label="期限日"
+              />
+              {editDueDate && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setEditDueDate('')}
+                  aria-label="日付をクリア"
+                >
+                  ✕
+                </Button>
+              )}
+            </div>
+          </div>
 
           <div className="flex gap-2">
             <Button


### PR DESCRIPTION
## Summary

- 日付フィールドに「日付（任意）」ラベルを追加し、入力可能であることを明示
- 日付設定後に✕ボタンでクリアできるようにし、日付の削除を可能に