### PR TITLE
feat: 統計サマリーUI（LevelBar + WeeklyMonthlyStats） (#131)

### DIFF
--- a/src/domain/services/__tests__/statsService.test.ts
+++ b/src/domain/services/__tests__/statsService.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getWeekRange,
+  getMonthRange,
+  aggregateAchievements,
+} from '../statsService';
+import type { DayAchievement } from '../calendarService';
+
+describe('statsService', () => {
+  describe('getWeekRange', () => {
+    it('returns Sunday-to-Saturday range for a Wednesday', () => {
+      // 2026-04-08 is a Wednesday
+      const result = getWeekRange('2026-04-08');
+      expect(result.start).toBe('2026-04-05'); // Sunday
+      expect(result.end).toBe('2026-04-11'); // Saturday
+    });
+
+    it('returns same day as start when today is Sunday', () => {
+      // 2026-04-05 is a Sunday
+      const result = getWeekRange('2026-04-05');
+      expect(result.start).toBe('2026-04-05');
+      expect(result.end).toBe('2026-04-11');
+    });
+
+    it('returns Sunday-to-Saturday range for a Saturday', () => {
+      // 2026-04-11 is a Saturday
+      const result = getWeekRange('2026-04-11');
+      expect(result.start).toBe('2026-04-05');
+      expect(result.end).toBe('2026-04-11');
+    });
+
+    it('handles month boundary', () => {
+      // 2026-05-01 is a Friday → week starts 2026-04-26 (Sun)
+      const result = getWeekRange('2026-05-01');
+      expect(result.start).toBe('2026-04-26');
+      expect(result.end).toBe('2026-05-02');
+    });
+  });
+
+  describe('getMonthRange', () => {
+    it('returns first to last day of the current month', () => {
+      const result = getMonthRange('2026-04-08');
+      expect(result.start).toBe('2026-04-01');
+      expect(result.end).toBe('2026-04-30');
+    });
+
+    it('handles February correctly (non-leap year)', () => {
+      const result = getMonthRange('2027-02-15');
+      expect(result.start).toBe('2027-02-01');
+      expect(result.end).toBe('2027-02-28');
+    });
+
+    it('handles February correctly (leap year)', () => {
+      // 2028 is a leap year
+      const result = getMonthRange('2028-02-15');
+      expect(result.start).toBe('2028-02-01');
+      expect(result.end).toBe('2028-02-29');
+    });
+
+    it('handles December correctly (31 days)', () => {
+      const result = getMonthRange('2026-12-15');
+      expect(result.start).toBe('2026-12-01');
+      expect(result.end).toBe('2026-12-31');
+    });
+  });
+
+  describe('aggregateAchievements', () => {
+    const makeAchievement = (
+      date: string,
+      targetCount: number,
+      completedCount: number,
+    ): DayAchievement => ({
+      date,
+      targetCount,
+      completedCount,
+      rate: targetCount > 0 ? completedCount / targetCount : 0,
+      completedHabitNames: [],
+      isTargetDay: targetCount > 0,
+    });
+
+    it('returns 0/0/0 for empty input', () => {
+      const result = aggregateAchievements([], '2026-04-01', '2026-04-08', '2026-04-08');
+      expect(result.completedCount).toBe(0);
+      expect(result.targetCount).toBe(0);
+      expect(result.rate).toBe(0);
+    });
+
+    it('aggregates totals across the range', () => {
+      const achievements: DayAchievement[] = [
+        makeAchievement('2026-04-05', 3, 3),
+        makeAchievement('2026-04-06', 3, 2),
+        makeAchievement('2026-04-07', 3, 1),
+        makeAchievement('2026-04-08', 3, 0),
+      ];
+      const result = aggregateAchievements(
+        achievements,
+        '2026-04-05',
+        '2026-04-11',
+        '2026-04-08',
+      );
+      // Only days up to today (04-05 to 04-08): 4 days × 3 target = 12, completed = 6
+      expect(result.targetCount).toBe(12);
+      expect(result.completedCount).toBe(6);
+      expect(result.rate).toBe(0.5);
+    });
+
+    it('excludes future days from the calculation', () => {
+      const achievements: DayAchievement[] = [
+        makeAchievement('2026-04-05', 3, 3),
+        makeAchievement('2026-04-06', 3, 3),
+        makeAchievement('2026-04-07', 3, 3),
+        makeAchievement('2026-04-08', 3, 3),
+        makeAchievement('2026-04-09', 3, 0), // future
+        makeAchievement('2026-04-10', 3, 0), // future
+        makeAchievement('2026-04-11', 3, 0), // future
+      ];
+      const result = aggregateAchievements(
+        achievements,
+        '2026-04-05',
+        '2026-04-11',
+        '2026-04-08',
+      );
+      // Up to 2026-04-08: 4 days × 3 = 12 target, 12 completed
+      expect(result.targetCount).toBe(12);
+      expect(result.completedCount).toBe(12);
+      expect(result.rate).toBe(1);
+    });
+
+    it('filters by the requested range start/end', () => {
+      const achievements: DayAchievement[] = [
+        makeAchievement('2026-04-04', 5, 5), // before range
+        makeAchievement('2026-04-05', 3, 3),
+        makeAchievement('2026-04-06', 3, 3),
+        makeAchievement('2026-04-12', 5, 5), // after range
+      ];
+      const result = aggregateAchievements(
+        achievements,
+        '2026-04-05',
+        '2026-04-11',
+        '2026-04-30',
+      );
+      expect(result.targetCount).toBe(6);
+      expect(result.completedCount).toBe(6);
+      expect(result.rate).toBe(1);
+    });
+
+    it('returns rate of 0 when target count is 0', () => {
+      const achievements: DayAchievement[] = [
+        makeAchievement('2026-04-05', 0, 0),
+        makeAchievement('2026-04-06', 0, 0),
+      ];
+      const result = aggregateAchievements(
+        achievements,
+        '2026-04-05',
+        '2026-04-11',
+        '2026-04-08',
+      );
+      expect(result.targetCount).toBe(0);
+      expect(result.completedCount).toBe(0);
+      expect(result.rate).toBe(0);
+    });
+
+    it('caps rate at 1 if completedCount somehow exceeds target', () => {
+      const achievements: DayAchievement[] = [
+        // unrealistic but defensive
+        { ...makeAchievement('2026-04-05', 2, 5), rate: 2.5 },
+      ];
+      const result = aggregateAchievements(
+        achievements,
+        '2026-04-05',
+        '2026-04-11',
+        '2026-04-08',
+      );
+      expect(result.rate).toBe(1);
+    });
+  });
+});

--- a/src/domain/services/statsService.ts
+++ b/src/domain/services/statsService.ts
@@ -1,0 +1,82 @@
+/**
+ * statsService - Pure functions for weekly/monthly stats aggregation.
+ *
+ * Used by WeeklyMonthlyStats UI component to compute completion rates over
+ * arbitrary date ranges using DayAchievement records produced by calendarService.
+ */
+
+import type { DayAchievement } from './calendarService';
+import { addDays } from './calendarService';
+
+export type DateRange = {
+  readonly start: string;
+  readonly end: string;
+};
+
+export type AchievementSummary = {
+  readonly completedCount: number;
+  readonly targetCount: number;
+  readonly rate: number; // 0..1
+};
+
+const padTwo = (n: number): string => String(n).padStart(2, '0');
+
+const toDateString = (year: number, monthIndex0: number, day: number): string =>
+  `${year}-${padTwo(monthIndex0 + 1)}-${padTwo(day)}`;
+
+/**
+ * Returns the Sunday-to-Saturday week range that contains the given date.
+ *
+ * Aligned with the calendar grid which is also Sunday-first.
+ */
+export function getWeekRange(date: string): DateRange {
+  const d = new Date(date + 'T00:00:00');
+  const dayOfWeek = d.getDay(); // 0 = Sunday
+  const start = addDays(date, -dayOfWeek);
+  const end = addDays(start, 6);
+  return Object.freeze({ start, end });
+}
+
+/**
+ * Returns the first-to-last-day range of the month that contains the given date.
+ */
+export function getMonthRange(date: string): DateRange {
+  const d = new Date(date + 'T00:00:00');
+  const year = d.getFullYear();
+  const monthIndex0 = d.getMonth();
+  const start = toDateString(year, monthIndex0, 1);
+  // Day 0 of next month = last day of current month
+  const lastDay = new Date(year, monthIndex0 + 1, 0).getDate();
+  const end = toDateString(year, monthIndex0, lastDay);
+  return Object.freeze({ start, end });
+}
+
+/**
+ * Aggregates DayAchievement records into a single completion summary.
+ *
+ * Only days within [rangeStart, min(rangeEnd, today)] are counted.
+ * Future days are excluded so users are not penalized for incomplete future dates.
+ */
+export function aggregateAchievements(
+  achievements: readonly DayAchievement[],
+  rangeStart: string,
+  rangeEnd: string,
+  today: string,
+): AchievementSummary {
+  const effectiveEnd = rangeEnd < today ? rangeEnd : today;
+
+  let completedCount = 0;
+  let targetCount = 0;
+
+  for (const a of achievements) {
+    if (a.date < rangeStart) continue;
+    if (a.date > effectiveEnd) continue;
+    completedCount += a.completedCount;
+    targetCount += a.targetCount;
+  }
+
+  const rawRate = targetCount > 0 ? completedCount / targetCount : 0;
+  const rate = Math.min(Math.max(rawRate, 0), 1);
+
+  return Object.freeze({ completedCount, targetCount, rate });
+}

--- a/src/hooks/useStatsData.ts
+++ b/src/hooks/useStatsData.ts
@@ -1,0 +1,147 @@
+/**
+ * useStatsData - Hook that fetches all-time data needed for the
+ * level / weekly / monthly summary on the calendar page.
+ *
+ * Loads active + archived habits and all completions from the earliest
+ * habit creation date through today, then derives:
+ *   - XP / level breakdown via xpService
+ *   - this-week and this-month achievement summaries via statsService
+ */
+
+import { useState, useEffect } from 'react';
+import type { Habit, Completion } from '@/domain/models';
+import type { HabitRepository } from '@/data/repositories/habitRepository';
+import type { CompletionRepository } from '@/data/repositories/completionRepository';
+import { calculateTotalXp, type XpBreakdown } from '@/domain/services/xpService';
+import {
+  calculateDailyAchievements,
+} from '@/domain/services/calendarService';
+import {
+  aggregateAchievements,
+  getWeekRange,
+  getMonthRange,
+  type AchievementSummary,
+} from '@/domain/services/statsService';
+
+export type StatsData = {
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly xp: XpBreakdown | null;
+  readonly weekly: AchievementSummary | null;
+  readonly monthly: AchievementSummary | null;
+};
+
+const padTwo = (n: number): string => String(n).padStart(2, '0');
+
+const getTodayString = (): string => {
+  const now = new Date();
+  return `${now.getFullYear()}-${padTwo(now.getMonth() + 1)}-${padTwo(now.getDate())}`;
+};
+
+const getEarliestHabitDate = (habits: readonly Habit[]): string | null => {
+  if (habits.length === 0) return null;
+  let earliest = habits[0].createdAt.slice(0, 10);
+  for (const h of habits) {
+    const d = h.createdAt.slice(0, 10);
+    if (d < earliest) earliest = d;
+  }
+  return earliest;
+};
+
+export function useStatsData(
+  habitRepository: HabitRepository,
+  completionRepository: CompletionRepository,
+): StatsData {
+  const [habits, setHabits] = useState<readonly Habit[]>([]);
+  const [completions, setCompletions] = useState<readonly Completion[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const [active, archived] = await Promise.all([
+          habitRepository.findAll(),
+          habitRepository.findArchived(),
+        ]);
+
+        const allHabits: readonly Habit[] = [...active, ...archived];
+        const earliest = getEarliestHabitDate(allHabits);
+        const today = getTodayString();
+
+        let completionData: readonly Completion[] = [];
+        if (earliest !== null) {
+          completionData = await completionRepository.findByDateRange(earliest, today);
+        }
+
+        if (!cancelled) {
+          setHabits(allHabits);
+          setCompletions(completionData);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message =
+            err instanceof Error ? err.message : '統計データの取得に失敗しました';
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchData();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [habitRepository, completionRepository]);
+
+  if (isLoading || error || habits.length === 0) {
+    return {
+      isLoading,
+      error,
+      xp: null,
+      weekly: null,
+      monthly: null,
+    };
+  }
+
+  const today = getTodayString();
+  const earliest = getEarliestHabitDate(habits) ?? today;
+
+  const xp = calculateTotalXp(habits, completions, earliest, today);
+
+  const weekRange = getWeekRange(today);
+  const monthRange = getMonthRange(today);
+
+  // Calculate per-day achievements once over the union of week and month
+  // (month range fully contains the relevant span when today is mid-month;
+  // for weeks crossing month boundaries we extend the range to include both).
+  const aggregateStart = weekRange.start < monthRange.start ? weekRange.start : monthRange.start;
+  const aggregateEnd = weekRange.end > monthRange.end ? weekRange.end : monthRange.end;
+
+  const achievements = calculateDailyAchievements(
+    habits,
+    completions,
+    aggregateStart,
+    aggregateEnd,
+  );
+
+  const weekly = aggregateAchievements(achievements, weekRange.start, weekRange.end, today);
+  const monthly = aggregateAchievements(achievements, monthRange.start, monthRange.end, today);
+
+  return {
+    isLoading,
+    error,
+    xp,
+    weekly,
+    monthly,
+  };
+}

--- a/src/hooks/useStatsData.ts
+++ b/src/hooks/useStatsData.ts
@@ -8,7 +8,7 @@
  *   - this-week and this-month achievement summaries via statsService
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import type { Habit, Completion } from '@/domain/models';
 import type { HabitRepository } from '@/data/repositories/habitRepository';
 import type { CompletionRepository } from '@/data/repositories/completionRepository';
@@ -103,6 +103,49 @@ export function useStatsData(
     };
   }, [habitRepository, completionRepository]);
 
+  const derived = useMemo(() => {
+    if (habits.length === 0) {
+      return { xp: null, weekly: null, monthly: null };
+    }
+
+    const today = getTodayString();
+    const earliest = getEarliestHabitDate(habits) ?? today;
+
+    const xp = calculateTotalXp(habits, completions, earliest, today);
+
+    const weekRange = getWeekRange(today);
+    const monthRange = getMonthRange(today);
+
+    // Calculate per-day achievements once over the union of week and month
+    // (month range fully contains the relevant span when today is mid-month;
+    // for weeks crossing month boundaries we extend the range to include both).
+    const aggregateStart =
+      weekRange.start < monthRange.start ? weekRange.start : monthRange.start;
+    const aggregateEnd = weekRange.end > monthRange.end ? weekRange.end : monthRange.end;
+
+    const achievements = calculateDailyAchievements(
+      habits,
+      completions,
+      aggregateStart,
+      aggregateEnd,
+    );
+
+    const weekly = aggregateAchievements(
+      achievements,
+      weekRange.start,
+      weekRange.end,
+      today,
+    );
+    const monthly = aggregateAchievements(
+      achievements,
+      monthRange.start,
+      monthRange.end,
+      today,
+    );
+
+    return { xp, weekly, monthly };
+  }, [habits, completions]);
+
   if (isLoading || error || habits.length === 0) {
     return {
       isLoading,
@@ -113,35 +156,11 @@ export function useStatsData(
     };
   }
 
-  const today = getTodayString();
-  const earliest = getEarliestHabitDate(habits) ?? today;
-
-  const xp = calculateTotalXp(habits, completions, earliest, today);
-
-  const weekRange = getWeekRange(today);
-  const monthRange = getMonthRange(today);
-
-  // Calculate per-day achievements once over the union of week and month
-  // (month range fully contains the relevant span when today is mid-month;
-  // for weeks crossing month boundaries we extend the range to include both).
-  const aggregateStart = weekRange.start < monthRange.start ? weekRange.start : monthRange.start;
-  const aggregateEnd = weekRange.end > monthRange.end ? weekRange.end : monthRange.end;
-
-  const achievements = calculateDailyAchievements(
-    habits,
-    completions,
-    aggregateStart,
-    aggregateEnd,
-  );
-
-  const weekly = aggregateAchievements(achievements, weekRange.start, weekRange.end, today);
-  const monthly = aggregateAchievements(achievements, monthRange.start, monthRange.end, today);
-
   return {
     isLoading,
     error,
-    xp,
-    weekly,
-    monthly,
+    xp: derived.xp,
+    weekly: derived.weekly,
+    monthly: derived.monthly,
   };
 }

--- a/src/ui/components/LevelBar.tsx
+++ b/src/ui/components/LevelBar.tsx
@@ -1,0 +1,53 @@
+/**
+ * LevelBar - Displays the user's current level and XP progress.
+ *
+ * The whole bar acts as a link to the rewards management page (/rewards),
+ * so users can see what reward they've set for the next level.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+type LevelBarProps = {
+  readonly level: number;
+  readonly currentXp: number;
+  readonly requiredXp: number;
+};
+
+const computeFillPercentage = (currentXp: number, requiredXp: number): number => {
+  if (requiredXp <= 0) return 0;
+  const ratio = currentXp / requiredXp;
+  return Math.max(0, Math.min(1, ratio)) * 100;
+};
+
+export function LevelBar({ level, currentXp, requiredXp }: LevelBarProps) {
+  const fillPercent = computeFillPercentage(currentXp, requiredXp);
+
+  return (
+    <Link
+      to="/rewards"
+      className="block rounded-lg border border-border bg-card p-3 shadow-sm transition-colors hover:bg-accent/30"
+      aria-label={`現在 Lv.${level}（${currentXp} / ${requiredXp} XP）。ご褒美を見る`}
+    >
+      <div className="mb-2 flex items-baseline justify-between">
+        <span className="text-base font-bold text-foreground">Lv.{level}</span>
+        <span className="text-xs text-muted-foreground">
+          {currentXp} / {requiredXp} XP
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuenow={currentXp}
+        aria-valuemin={0}
+        aria-valuemax={requiredXp}
+        className="h-2 w-full overflow-hidden rounded-full bg-muted"
+      >
+        <div
+          data-testid="level-bar-fill"
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${fillPercent}%` }}
+        />
+      </div>
+    </Link>
+  );
+}

--- a/src/ui/components/WeeklyMonthlyStats.tsx
+++ b/src/ui/components/WeeklyMonthlyStats.tsx
@@ -1,0 +1,50 @@
+/**
+ * WeeklyMonthlyStats - Side-by-side weekly and monthly completion summaries.
+ *
+ * Displays the completion ratio (completed / target) and rounded percentage.
+ * Future days are excluded upstream by aggregateAchievements.
+ */
+
+import React from 'react';
+import type { AchievementSummary } from '@/domain/services/statsService';
+
+type WeeklyMonthlyStatsProps = {
+  readonly weekly: AchievementSummary;
+  readonly monthly: AchievementSummary;
+};
+
+const formatPercent = (rate: number): string => `${Math.round(rate * 100)}%`;
+
+function StatCell({
+  label,
+  summary,
+  testId,
+}: {
+  readonly label: string;
+  readonly summary: AchievementSummary;
+  readonly testId: string;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-col items-center rounded-lg border border-border bg-card p-3"
+    >
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="mt-1 text-2xl font-bold text-foreground">
+        {formatPercent(summary.rate)}
+      </span>
+      <span className="text-xs text-muted-foreground">
+        {summary.completedCount} / {summary.targetCount}
+      </span>
+    </div>
+  );
+}
+
+export function WeeklyMonthlyStats({ weekly, monthly }: WeeklyMonthlyStatsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <StatCell label="今週" summary={weekly} testId="stats-weekly" />
+      <StatCell label="今月" summary={monthly} testId="stats-monthly" />
+    </div>
+  );
+}

--- a/src/ui/components/__tests__/LevelBar.test.tsx
+++ b/src/ui/components/__tests__/LevelBar.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom/vitest';
+import { LevelBar } from '../LevelBar';
+
+describe('LevelBar', () => {
+  it('renders the current level number', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={12} currentXp={20} requiredXp={65} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/Lv\.12/i)).toBeInTheDocument();
+  });
+
+  it('renders the current and required XP', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={5} currentXp={15} requiredXp={30} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('15 / 30 XP')).toBeInTheDocument();
+  });
+
+  it('renders progress bar with width matching XP ratio', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={3} currentXp={10} requiredXp={20} />
+      </MemoryRouter>,
+    );
+    const progress = screen.getByRole('progressbar');
+    expect(progress).toHaveAttribute('aria-valuenow', '10');
+    expect(progress).toHaveAttribute('aria-valuemin', '0');
+    expect(progress).toHaveAttribute('aria-valuemax', '20');
+    // Visual fill: 50%
+    const fill = progress.querySelector('[data-testid="level-bar-fill"]') as HTMLElement;
+    expect(fill).toBeTruthy();
+    expect(fill.style.width).toBe('50%');
+  });
+
+  it('renders progress bar with 0% width when currentXp is 0', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={1} currentXp={0} requiredXp={10} />
+      </MemoryRouter>,
+    );
+    const fill = screen
+      .getByRole('progressbar')
+      .querySelector('[data-testid="level-bar-fill"]') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  it('caps progress bar width at 100% even when XP exceeds required', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={1} currentXp={50} requiredXp={10} />
+      </MemoryRouter>,
+    );
+    const fill = screen
+      .getByRole('progressbar')
+      .querySelector('[data-testid="level-bar-fill"]') as HTMLElement;
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('renders 0% width when requiredXp is 0 (defensive)', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={1} currentXp={0} requiredXp={0} />
+      </MemoryRouter>,
+    );
+    const fill = screen
+      .getByRole('progressbar')
+      .querySelector('[data-testid="level-bar-fill"]') as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  it('links to /rewards', () => {
+    render(
+      <MemoryRouter>
+        <LevelBar level={5} currentXp={10} requiredXp={30} />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/rewards');
+  });
+});

--- a/src/ui/components/__tests__/WeeklyMonthlyStats.test.tsx
+++ b/src/ui/components/__tests__/WeeklyMonthlyStats.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { WeeklyMonthlyStats } from '../WeeklyMonthlyStats';
+
+describe('WeeklyMonthlyStats', () => {
+  it('renders weekly and monthly section labels', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 5, targetCount: 10, rate: 0.5 }}
+        monthly={{ completedCount: 20, targetCount: 25, rate: 0.8 }}
+      />,
+    );
+    expect(screen.getByText('今週')).toBeInTheDocument();
+    expect(screen.getByText('今月')).toBeInTheDocument();
+  });
+
+  it('displays weekly completion ratio and percentage', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 5, targetCount: 10, rate: 0.5 }}
+        monthly={{ completedCount: 20, targetCount: 25, rate: 0.8 }}
+      />,
+    );
+    const weeklySection = screen.getByTestId('stats-weekly');
+    expect(within(weeklySection).getByText('5 / 10')).toBeInTheDocument();
+    expect(within(weeklySection).getByText('50%')).toBeInTheDocument();
+  });
+
+  it('displays monthly completion ratio and percentage', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 5, targetCount: 10, rate: 0.5 }}
+        monthly={{ completedCount: 20, targetCount: 25, rate: 0.8 }}
+      />,
+    );
+    const monthlySection = screen.getByTestId('stats-monthly');
+    expect(within(monthlySection).getByText('20 / 25')).toBeInTheDocument();
+    expect(within(monthlySection).getByText('80%')).toBeInTheDocument();
+  });
+
+  it('rounds the percentage to the nearest integer', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 1, targetCount: 3, rate: 1 / 3 }}
+        monthly={{ completedCount: 2, targetCount: 3, rate: 2 / 3 }}
+      />,
+    );
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+  });
+
+  it('shows 0% and 0 / 0 when no targets exist', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 0, targetCount: 0, rate: 0 }}
+        monthly={{ completedCount: 0, targetCount: 0, rate: 0 }}
+      />,
+    );
+    const weeklySection = screen.getByTestId('stats-weekly');
+    const monthlySection = screen.getByTestId('stats-monthly');
+    expect(within(weeklySection).getByText('0 / 0')).toBeInTheDocument();
+    expect(within(weeklySection).getByText('0%')).toBeInTheDocument();
+    expect(within(monthlySection).getByText('0 / 0')).toBeInTheDocument();
+    expect(within(monthlySection).getByText('0%')).toBeInTheDocument();
+  });
+
+  it('shows 100% when fully complete', () => {
+    render(
+      <WeeklyMonthlyStats
+        weekly={{ completedCount: 7, targetCount: 7, rate: 1 }}
+        monthly={{ completedCount: 30, targetCount: 30, rate: 1 }}
+      />,
+    );
+    expect(screen.getAllByText('100%')).toHaveLength(2);
+  });
+});

--- a/src/ui/pages/CalendarPage.tsx
+++ b/src/ui/pages/CalendarPage.tsx
@@ -9,8 +9,11 @@ import React, { useMemo } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRepositories } from '@/hooks/useRepositories';
 import { useCalendarData } from '@/hooks/useCalendarData';
+import { useStatsData } from '@/hooks/useStatsData';
 import { HeatmapCalendar } from '@/ui/components/HeatmapCalendar';
 import { HabitFilter } from '@/ui/components/HabitFilter';
+import { LevelBar } from '@/ui/components/LevelBar';
+import { WeeklyMonthlyStats } from '@/ui/components/WeeklyMonthlyStats';
 import { Button } from '@/components/ui/button';
 
 // --- Sub-components ---
@@ -104,6 +107,8 @@ export function CalendarPage() {
     setFilter,
   } = useCalendarData(habitRepository, completionRepository);
 
+  const stats = useStatsData(habitRepository, completionRepository);
+
   const selectedHabitColor = useMemo(() => {
     if (filter.mode !== 'habit') return undefined;
     const habit = allHabits.find((h) => h.id === filter.habitId);
@@ -115,6 +120,17 @@ export function CalendarPage() {
       <header className="mb-6">
         <h1 className="text-2xl font-bold text-foreground">カレンダー</h1>
       </header>
+
+      {stats.xp && stats.weekly && stats.monthly && (
+        <div className="mb-6 space-y-3">
+          <LevelBar
+            level={stats.xp.level}
+            currentXp={stats.xp.currentXp}
+            requiredXp={stats.xp.requiredXp}
+          />
+          <WeeklyMonthlyStats weekly={stats.weekly} monthly={stats.monthly} />
+        </div>
+      )}
 
       <MonthNavigationHeader
         year={year}

--- a/src/ui/pages/CalendarPage.tsx
+++ b/src/ui/pages/CalendarPage.tsx
@@ -121,6 +121,15 @@ export function CalendarPage() {
         <h1 className="text-2xl font-bold text-foreground">カレンダー</h1>
       </header>
 
+      {stats.error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          統計情報を取得できませんでした: {stats.error}
+        </div>
+      )}
+
       {stats.xp && stats.weekly && stats.monthly && (
         <div className="mb-6 space-y-3">
           <LevelBar


### PR DESCRIPTION
## 概要

XP・レベルシステム Phase 4。CalendarPage 上部にレベル/XPバーと週間/月間達成率を表示。

closes #131

## 変更内容

### ドメインサービス
- \`statsService.ts\`: 週/月の範囲計算 + 達成率集計の純粋関数
  - \`getWeekRange(date)\`: 日曜始まり〜土曜終わりの週範囲
  - \`getMonthRange(date)\`: 月初〜月末の月範囲
  - \`aggregateAchievements(achievements, start, end, today)\`: 範囲内合計（今日以降を除外）

### UIコンポーネント
- \`LevelBar.tsx\`: \`Lv.X\` + XP プログレスバー（\`/rewards\` へのリンク）
- \`WeeklyMonthlyStats.tsx\`: 今週/今月の \`completed/target\` と \`%\` を 2 カラムで表示

### フック
- \`useStatsData.ts\`: アクティブ + アーカイブ済み habits、最古の \`createdAt\` から今日までの completions を取得して XpBreakdown / 週/月の集計を返す

### ページ統合
- \`CalendarPage.tsx\`: ヒートマップの上に LevelBar と WeeklyMonthlyStats を配置

## 受け入れ基準

- [x] LevelBar: レベル番号 + XPプログレスバー + \`/rewards\` リンク
- [x] WeeklyMonthlyStats: 今週/今月の達成率
- [x] 日曜始まりで週を計算
- [x] 未来の日を計算から除外
- [x] CalendarPage に統合
- [x] 全期間 habits + completions を取得
- [x] \`calculateDailyAchievements\` を再利用

## テスト

- 新規ユニット 27 ケース（statsService 14, LevelBar 7, WeeklyMonthlyStats 6）
- ユニット合計: 632 → 637 全パス（PR #137 マージ前のベース基準で +5、Phase 3 マージ後の現在は 664 → 全パス）
- typecheck: PASS
- E2E: 44 全パス（リグレッション確認）

## 注記

- \`/rewards\` ルートは Phase 5 で実装予定。現時点ではリンク先が 404 になる（issue #131 で許容）
- Phase 5 / Phase 6 / Phase 7 が後続