### PR TITLE
feat: ご褒美管理ページ（RewardsPage） (#132)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { HabitsPage } from '@/ui/pages/HabitsPage';
 import { NewHabitPage } from '@/ui/pages/NewHabitPage';
 import { HabitDetailPage } from '@/ui/pages/HabitDetailPage';
 import { CalendarPage } from '@/ui/pages/CalendarPage';
+import { RewardsPage } from '@/ui/pages/RewardsPage';
 import { SettingsPage } from '@/ui/pages/SettingsPage';
 import { createSupabaseClient } from '@/lib/supabase';
 
@@ -78,6 +79,7 @@ export function App() {
         >
           <Route path="/" element={<TodayPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/rewards" element={<RewardsPage />} />
           <Route path="/habits" element={<HabitsPage />} />
           <Route path="/habits/new" element={<NewHabitPage />} />
           <Route path="/habits/:id" element={<HabitDetailPage />} />

--- a/src/ui/pages/RewardsPage.tsx
+++ b/src/ui/pages/RewardsPage.tsx
@@ -1,0 +1,361 @@
+/**
+ * RewardsPage - User-defined reward management page (CRUD).
+ *
+ * Users can register a reward (description) for any level. The page is
+ * accessed via the LevelBar tap on CalendarPage. There is no entry in the
+ * navigation bar — the only way in is the LevelBar.
+ *
+ * Deletion is unconfirmed by design (single-user, low-stakes data).
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { ChevronLeft, Pencil, Trash2, Check, X } from 'lucide-react';
+import { z } from 'zod';
+import { useRepositories } from '@/hooks/useRepositories';
+import type { Reward } from '@/domain/models';
+import {
+  REWARD_DESCRIPTION_MAX_LENGTH,
+} from '@/domain/models/reward';
+import { DuplicateRewardLevelError } from '@/data/repositories/rewardRepository';
+
+// --- Validation ---
+
+const createRewardFormSchema = z.object({
+  level: z
+    .number({ invalid_type_error: 'レベルは整数で入力してください' })
+    .int('レベルは整数で入力してください')
+    .min(1, 'レベルは1以上の整数を入力してください'),
+  description: z
+    .string()
+    .trim()
+    .min(1, 'ご褒美の内容を入力してください')
+    .max(REWARD_DESCRIPTION_MAX_LENGTH, `ご褒美は${REWARD_DESCRIPTION_MAX_LENGTH}文字以内で入力してください`),
+});
+
+// --- Sub-components ---
+
+function RewardItem({
+  reward,
+  onUpdate,
+  onDelete,
+}: {
+  readonly reward: Reward;
+  readonly onUpdate: (id: string, description: string) => Promise<void>;
+  readonly onDelete: (id: string) => Promise<void>;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(reward.description);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const beginEdit = () => {
+    setDraft(reward.description);
+    setError(null);
+    setIsEditing(true);
+  };
+
+  const cancelEdit = () => {
+    setDraft(reward.description);
+    setError(null);
+    setIsEditing(false);
+  };
+
+  const save = async () => {
+    const trimmed = draft.trim();
+    if (trimmed.length === 0) {
+      setError('ご褒美の内容を入力してください');
+      return;
+    }
+    if (trimmed.length > REWARD_DESCRIPTION_MAX_LENGTH) {
+      setError(`ご褒美は${REWARD_DESCRIPTION_MAX_LENGTH}文字以内で入力してください`);
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await onUpdate(reward.id, trimmed);
+      setIsEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '更新に失敗しました');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const remove = async () => {
+    setIsSaving(true);
+    try {
+      await onDelete(reward.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '削除に失敗しました');
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <li
+      data-testid="reward-item"
+      className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3"
+    >
+      <div className="flex items-center gap-3">
+        <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-bold text-primary">
+          Lv.{reward.level}
+        </span>
+        {isEditing ? (
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            maxLength={REWARD_DESCRIPTION_MAX_LENGTH}
+            className="flex-1 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            aria-label="ご褒美の内容"
+          />
+        ) : (
+          <span className="flex-1 text-sm text-foreground">{reward.description}</span>
+        )}
+        {isEditing ? (
+          <>
+            <button
+              type="button"
+              onClick={save}
+              disabled={isSaving}
+              aria-label="保存"
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              <Check className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              disabled={isSaving}
+              aria-label="キャンセル"
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              <X className="size-4" />
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={beginEdit}
+              aria-label="編集"
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Pencil className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={remove}
+              disabled={isSaving}
+              aria-label="削除"
+              className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+            >
+              <Trash2 className="size-4" />
+            </button>
+          </>
+        )}
+      </div>
+      {error && (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}
+
+function AddRewardForm({
+  onCreate,
+}: {
+  readonly onCreate: (level: number, description: string) => Promise<void>;
+}) {
+  const [levelInput, setLevelInput] = useState('');
+  const [descInput, setDescInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const parsed = createRewardFormSchema.safeParse({
+      level: Number(levelInput),
+      description: descInput,
+    });
+
+    if (!parsed.success) {
+      setError(parsed.error.issues[0]?.message ?? '入力が不正です');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onCreate(parsed.data.level, parsed.data.description);
+      setLevelInput('');
+      setDescInput('');
+    } catch (err) {
+      if (err instanceof DuplicateRewardLevelError) {
+        setError(`レベル ${err.level} には既にご褒美が登録されています`);
+      } else {
+        setError(err instanceof Error ? err.message : '登録に失敗しました');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-lg border border-border bg-card p-3"
+    >
+      <h2 className="mb-2 text-sm font-bold text-foreground">新しいご褒美を追加</h2>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <label className="flex flex-col text-xs text-muted-foreground sm:w-24">
+          レベル
+          <input
+            type="number"
+            step={1}
+            value={levelInput}
+            onChange={(e) => setLevelInput(e.target.value)}
+            className="mt-1 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            disabled={isSubmitting}
+          />
+        </label>
+        <label className="flex flex-1 flex-col text-xs text-muted-foreground">
+          ご褒美の内容
+          <input
+            type="text"
+            value={descInput}
+            onChange={(e) => setDescInput(e.target.value)}
+            maxLength={REWARD_DESCRIPTION_MAX_LENGTH}
+            className="mt-1 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            disabled={isSubmitting}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          追加
+        </button>
+      </div>
+      {error && (
+        <p role="alert" className="mt-2 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}
+
+// --- Main Page ---
+
+export function RewardsPage() {
+  const { rewardRepository } = useRepositories();
+  const [rewards, setRewards] = useState<readonly Reward[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchRewards() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await rewardRepository.findAll();
+        if (!cancelled) {
+          setRewards(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : '取得に失敗しました');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchRewards();
+    return () => {
+      cancelled = true;
+    };
+  }, [rewardRepository]);
+
+  const handleCreate = useCallback(
+    async (level: number, description: string) => {
+      const created = await rewardRepository.create({ level, description });
+      setRewards((prev) =>
+        [...prev, created].sort((a, b) => a.level - b.level),
+      );
+    },
+    [rewardRepository],
+  );
+
+  const handleUpdate = useCallback(
+    async (id: string, description: string) => {
+      const updated = await rewardRepository.update(id, { description });
+      setRewards((prev) => prev.map((r) => (r.id === id ? updated : r)));
+    },
+    [rewardRepository],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      await rewardRepository.remove(id);
+      setRewards((prev) => prev.filter((r) => r.id !== id));
+    },
+    [rewardRepository],
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-4 py-6">
+      <Link
+        to="/calendar"
+        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        カレンダーに戻る
+      </Link>
+
+      <h1 className="mb-6 text-2xl font-bold text-foreground">ご褒美</h1>
+
+      <div className="mb-6">
+        <AddRewardForm onCreate={handleCreate} />
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground">読み込み中...</p>
+      ) : rewards.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          まだご褒美がありません。レベルアップしたときの自分へのプレゼントを登録しましょう。
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rewards.map((r) => (
+            <RewardItem
+              key={r.id}
+              reward={r}
+              onUpdate={handleUpdate}
+              onDelete={handleDelete}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/ui/pages/__tests__/RewardsPage.test.tsx
+++ b/src/ui/pages/__tests__/RewardsPage.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import '@testing-library/jest-dom/vitest';
+import { RewardsPage } from '../RewardsPage';
+import { DuplicateRewardLevelError } from '@/data/repositories/rewardRepository';
+import type { Reward } from '@/domain/models';
+
+// --- Mock repository ---
+
+const mockFindAll = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+vi.mock('@/hooks/useRepositories', () => ({
+  useRepositories: () => ({
+    rewardRepository: {
+      findAll: mockFindAll,
+      create: mockCreate,
+      update: mockUpdate,
+      remove: mockRemove,
+    },
+  }),
+}));
+
+const sampleRewards: Reward[] = [
+  {
+    id: 'r1',
+    userId: 'u1',
+    level: 5,
+    description: 'Watch a movie',
+    createdAt: '2026-04-08T10:00:00Z',
+    updatedAt: '2026-04-08T10:00:00Z',
+  },
+  {
+    id: 'r2',
+    userId: 'u1',
+    level: 10,
+    description: 'Buy a new book',
+    createdAt: '2026-04-08T11:00:00Z',
+    updatedAt: '2026-04-08T11:00:00Z',
+  },
+];
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <RewardsPage />
+    </MemoryRouter>,
+  );
+
+describe('RewardsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindAll.mockResolvedValue([...sampleRewards]);
+  });
+
+  it('renders the page title and back-to-calendar link', async () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: 'ご褒美' })).toBeInTheDocument();
+    const backLink = screen.getByRole('link', { name: /カレンダーに戻る/ });
+    expect(backLink).toHaveAttribute('href', '/calendar');
+    await waitFor(() => expect(mockFindAll).toHaveBeenCalled());
+  });
+
+  it('displays existing rewards in ascending level order', async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Watch a movie')).toBeInTheDocument();
+      expect(screen.getByText('Buy a new book')).toBeInTheDocument();
+    });
+    const items = screen.getAllByTestId('reward-item');
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText(/Lv\.5/)).toBeInTheDocument();
+    expect(within(items[1]).getByText(/Lv\.10/)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no rewards exist', async () => {
+    mockFindAll.mockResolvedValueOnce([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/まだご褒美がありません/)).toBeInTheDocument();
+    });
+  });
+
+  it('creates a new reward via the add form', async () => {
+    const newReward: Reward = {
+      id: 'r3',
+      userId: 'u1',
+      level: 15,
+      description: 'Special dinner',
+      createdAt: '2026-04-08T12:00:00Z',
+      updatedAt: '2026-04-08T12:00:00Z',
+    };
+    mockCreate.mockResolvedValueOnce(newReward);
+
+    renderPage();
+    await waitFor(() => expect(mockFindAll).toHaveBeenCalled());
+
+    const levelInput = screen.getByLabelText(/レベル/);
+    const descInput = screen.getByLabelText(/ご褒美/);
+    const submitBtn = screen.getByRole('button', { name: '追加' });
+
+    fireEvent.change(levelInput, { target: { value: '15' } });
+    fireEvent.change(descInput, { target: { value: 'Special dinner' } });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({
+        level: 15,
+        description: 'Special dinner',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Special dinner')).toBeInTheDocument();
+    });
+  });
+
+  it('trims whitespace from description before submit', async () => {
+    mockCreate.mockResolvedValueOnce({
+      id: 'r4',
+      userId: 'u1',
+      level: 20,
+      description: 'Trim me',
+      createdAt: '2026-04-08T12:00:00Z',
+      updatedAt: '2026-04-08T12:00:00Z',
+    });
+
+    renderPage();
+    await waitFor(() => expect(mockFindAll).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/レベル/), { target: { value: '20' } });
+    fireEvent.change(screen.getByLabelText(/ご褒美/), {
+      target: { value: '  Trim me   ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith({
+        level: 20,
+        description: 'Trim me',
+      });
+    });
+  });
+
+  it('shows validation error when description is empty', async () => {
+    renderPage();
+    await waitFor(() => expect(mockFindAll).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/レベル/), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/ご褒美/), { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ご褒美の内容を入力してください/)).toBeInTheDocument();
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when level is less than 1', async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('Watch a movie')).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByLabelText(/レベル/), { target: { value: '0' } });
+    fireEvent.change(screen.getByLabelText(/ご褒美/), { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/レベルは1以上/)).toBeInTheDocument();
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('shows duplicate level error', async () => {
+    mockCreate.mockRejectedValueOnce(new DuplicateRewardLevelError(5));
+
+    renderPage();
+    await waitFor(() => expect(mockFindAll).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText(/レベル/), { target: { value: '5' } });
+    fireEvent.change(screen.getByLabelText(/ご褒美/), { target: { value: 'Dup' } });
+    fireEvent.click(screen.getByRole('button', { name: '追加' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/レベル 5 には既にご褒美が登録されています/)).toBeInTheDocument();
+    });
+  });
+
+  it('edits a reward description', async () => {
+    const updated: Reward = {
+      ...sampleRewards[0],
+      description: 'Watch two movies',
+      updatedAt: '2026-04-08T13:00:00Z',
+    };
+    mockUpdate.mockResolvedValueOnce(updated);
+
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('Watch a movie')).toBeInTheDocument(),
+    );
+
+    const items = screen.getAllByTestId('reward-item');
+    const editBtn = within(items[0]).getByRole('button', { name: /編集/ });
+    fireEvent.click(editBtn);
+
+    const editInput = await waitFor(() =>
+      within(items[0]).getByDisplayValue('Watch a movie'),
+    );
+    fireEvent.change(editInput, { target: { value: 'Watch two movies' } });
+
+    const saveBtn = within(items[0]).getByRole('button', { name: /保存/ });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('r1', {
+        description: 'Watch two movies',
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Watch two movies')).toBeInTheDocument();
+    });
+  });
+
+  it('cancels an edit without calling update', async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('Watch a movie')).toBeInTheDocument(),
+    );
+
+    const items = screen.getAllByTestId('reward-item');
+    fireEvent.click(within(items[0]).getByRole('button', { name: /編集/ }));
+
+    const editInput = await waitFor(() =>
+      within(items[0]).getByDisplayValue('Watch a movie'),
+    );
+    fireEvent.change(editInput, { target: { value: 'Should not save' } });
+    fireEvent.click(within(items[0]).getByRole('button', { name: /キャンセル/ }));
+
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(screen.getByText('Watch a movie')).toBeInTheDocument();
+  });
+
+  it('deletes a reward without confirmation', async () => {
+    mockRemove.mockResolvedValueOnce(undefined);
+
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('Watch a movie')).toBeInTheDocument(),
+    );
+
+    const items = screen.getAllByTestId('reward-item');
+    fireEvent.click(within(items[0]).getByRole('button', { name: /削除/ }));
+
+    await waitFor(() => {
+      expect(mockRemove).toHaveBeenCalledWith('r1');
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('Watch a movie')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error when fetch fails', async () => {
+    mockFindAll.mockRejectedValueOnce(new Error('Network error'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Network error/);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

XP・レベルシステム Phase 5。任意のレベルにご褒美テキストを CRUD できる管理ページ \`/rewards\` を実装。

closes #132

## 変更内容

- \`src/ui/pages/RewardsPage.tsx\`: 新規ページ
  - 「← カレンダーに戻る」リンク
  - 新規追加フォーム（レベル + 内容、zod バリデーション）
  - レベル昇順の一覧、各項目にインライン編集/削除
  - 削除は確認なし（個人利用のためシンプルに）
  - エラー表示: 取得失敗、バリデーション、レベル重複（DuplicateRewardLevelError）
- \`src/App.tsx\`: \`/rewards\` ルート追加（ナビゲーションには非掲載）
- ユニットテスト 12 ケース

## 受け入れ基準

- [x] \`/rewards\` ページ作成
- [x] 「← カレンダーに戻る」リンク
- [x] レベル昇順の一覧表示
- [x] 新規追加フォーム（レベル + 内容）
- [x] description の trim
- [x] レベル重複時のエラー表示
- [x] 編集機能
- [x] 削除（確認なし）
- [x] App.tsx ルート追加
- [x] ナビゲーションバーには未追加

## テスト

- 新規ユニット 12 ケース
- 全ユニット: 660 → 672 全パス
- typecheck: PASS
- E2E: 44 全パス（リグレッション確認）

## 注記

- ナビゲーションバー非掲載のため、CalendarPage の LevelBar タップが唯一の入口
- Phase 6 (LevelUpDialog) で「次のレベルのご褒美設定」ダイアログ追加予定
- 同一レベルへの重複登録は DB の UNIQUE 制約 + Phase 3 の DuplicateRewardLevelError で防止