### PR TITLE
feat: レベルアップダイアログ（LevelUpDialog） (#133)

### DIFF
--- a/src/hooks/__tests__/useLevelUpDetection.test.ts
+++ b/src/hooks/__tests__/useLevelUpDetection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import {
+  useLevelUpDetection,
+  LEVEL_STORAGE_KEY,
+} from '../useLevelUpDetection';
+
+describe('useLevelUpDetection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns null event on first run and persists current level', () => {
+    const { result } = renderHook(() => useLevelUpDetection(5));
+    expect(result.current.event).toBeNull();
+    expect(localStorage.getItem(LEVEL_STORAGE_KEY)).toBe('5');
+  });
+
+  it('returns null event when level is unchanged', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, '5');
+    const { result } = renderHook(() => useLevelUpDetection(5));
+    expect(result.current.event).toBeNull();
+  });
+
+  it('returns null event when level is null (data not loaded yet)', () => {
+    const { result } = renderHook(() => useLevelUpDetection(null));
+    expect(result.current.event).toBeNull();
+    expect(localStorage.getItem(LEVEL_STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns level-up event when current level is greater than stored', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, '3');
+    const { result } = renderHook(() => useLevelUpDetection(4));
+    expect(result.current.event).not.toBeNull();
+    expect(result.current.event?.previousLevel).toBe(3);
+    expect(result.current.event?.newLevel).toBe(4);
+  });
+
+  it('handles multi-level jumps (3 → 5)', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, '3');
+    const { result } = renderHook(() => useLevelUpDetection(5));
+    expect(result.current.event?.previousLevel).toBe(3);
+    expect(result.current.event?.newLevel).toBe(5);
+  });
+
+  it('does not return event when level decreased (defensive)', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, '5');
+    const { result } = renderHook(() => useLevelUpDetection(3));
+    expect(result.current.event).toBeNull();
+    // Stored level is updated to current to prevent stale state
+    expect(localStorage.getItem(LEVEL_STORAGE_KEY)).toBe('3');
+  });
+
+  it('updates localStorage when dismiss is called', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, '3');
+    const { result } = renderHook(() => useLevelUpDetection(4));
+    expect(result.current.event).not.toBeNull();
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.event).toBeNull();
+    expect(localStorage.getItem(LEVEL_STORAGE_KEY)).toBe('4');
+  });
+
+  it('handles invalid stored value (NaN) as first run', () => {
+    localStorage.setItem(LEVEL_STORAGE_KEY, 'not-a-number');
+    const { result } = renderHook(() => useLevelUpDetection(5));
+    expect(result.current.event).toBeNull();
+    expect(localStorage.getItem(LEVEL_STORAGE_KEY)).toBe('5');
+  });
+});

--- a/src/hooks/useLevelUpDetection.ts
+++ b/src/hooks/useLevelUpDetection.ts
@@ -1,0 +1,88 @@
+/**
+ * useLevelUpDetection - Detects level-ups by comparing the current level
+ * with the level stored in localStorage from the previous visit.
+ *
+ * Behavior:
+ *  - First run (no stored value): no event, current level is persisted.
+ *  - Same level: no event.
+ *  - Higher level: returns a level-up event with previous and new level.
+ *  - Lower level (defensive): no event, stored level is updated to current.
+ *  - Invalid stored value (NaN): treated as first run.
+ *  - `currentLevel === null` (data not loaded): no event, no persistence.
+ *
+ * The dismiss callback updates localStorage to the new level so the dialog
+ * is not shown again for the same transition.
+ */
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+export const LEVEL_STORAGE_KEY = 'daily-rituals-last-level';
+
+export type LevelUpEvent = {
+  readonly previousLevel: number;
+  readonly newLevel: number;
+};
+
+export type UseLevelUpDetectionReturn = {
+  readonly event: LevelUpEvent | null;
+  readonly dismiss: () => void;
+};
+
+const readStoredLevel = (): number | null => {
+  if (typeof window === 'undefined') return null;
+  const raw = window.localStorage.getItem(LEVEL_STORAGE_KEY);
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  if (Number.isNaN(parsed) || !Number.isFinite(parsed)) return null;
+  return parsed;
+};
+
+const writeStoredLevel = (level: number): void => {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(LEVEL_STORAGE_KEY, String(level));
+};
+
+export function useLevelUpDetection(
+  currentLevel: number | null,
+): UseLevelUpDetectionReturn {
+  const [event, setEvent] = useState<LevelUpEvent | null>(null);
+  const lastProcessedLevel = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (currentLevel === null) return;
+
+    // Avoid reprocessing the same level on re-renders
+    if (lastProcessedLevel.current === currentLevel) return;
+    lastProcessedLevel.current = currentLevel;
+
+    const stored = readStoredLevel();
+
+    if (stored === null) {
+      // First run or invalid value: just persist
+      writeStoredLevel(currentLevel);
+      return;
+    }
+
+    if (currentLevel > stored) {
+      setEvent({ previousLevel: stored, newLevel: currentLevel });
+      return;
+    }
+
+    if (currentLevel < stored) {
+      // Defensive: keep storage in sync if level somehow regressed
+      writeStoredLevel(currentLevel);
+      return;
+    }
+
+    // currentLevel === stored: no-op
+  }, [currentLevel]);
+
+  const dismiss = useCallback(() => {
+    if (event !== null) {
+      writeStoredLevel(event.newLevel);
+    }
+    setEvent(null);
+  }, [event]);
+
+  return { event, dismiss };
+}

--- a/src/ui/components/LevelUpDialog.tsx
+++ b/src/ui/components/LevelUpDialog.tsx
@@ -1,0 +1,86 @@
+/**
+ * LevelUpDialog - Modal shown when the user reaches a new level.
+ *
+ * Props are fully controlled by the parent. When `open` is false the
+ * component renders nothing. The reward section is only shown when a
+ * reward description is provided for the new level.
+ */
+
+import React from 'react';
+import { Sparkles, X } from 'lucide-react';
+
+type LevelUpDialogProps = {
+  readonly open: boolean;
+  readonly previousLevel: number;
+  readonly newLevel: number;
+  readonly rewardDescription: string | null;
+  readonly onClose: () => void;
+};
+
+export function LevelUpDialog({
+  open,
+  previousLevel,
+  newLevel,
+  rewardDescription,
+  onClose,
+}: LevelUpDialogProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="level-up-title"
+        className="relative w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label="ダイアログを閉じる"
+          onClick={onClose}
+          className="absolute right-3 top-3 rounded-full p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <X className="size-5" />
+        </button>
+
+        <div className="flex flex-col items-center text-center">
+          <Sparkles className="mb-3 size-10 text-primary" aria-hidden />
+          <h2
+            id="level-up-title"
+            className="text-2xl font-bold text-foreground"
+          >
+            レベルアップ！
+          </h2>
+          <p className="mt-3 text-base text-muted-foreground">
+            <span className="font-bold text-foreground">Lv.{previousLevel}</span>
+            <span className="mx-2">→</span>
+            <span className="text-2xl font-bold text-primary">Lv.{newLevel}</span>
+          </p>
+
+          {rewardDescription !== null && (
+            <div className="mt-5 w-full rounded-lg border border-primary/40 bg-primary/10 p-3">
+              <p className="text-xs font-bold uppercase tracking-wide text-primary">
+                ご褒美
+              </p>
+              <p className="mt-1 text-sm text-foreground">{rewardDescription}</p>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={onClose}
+            className="mt-5 w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/__tests__/LevelUpDialog.test.tsx
+++ b/src/ui/components/__tests__/LevelUpDialog.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { LevelUpDialog } from '../LevelUpDialog';
+
+describe('LevelUpDialog', () => {
+  it('does not render anything when open is false', () => {
+    const { container } = render(
+      <LevelUpDialog
+        open={false}
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the title and level transition when open', () => {
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText('レベルアップ！')).toBeInTheDocument();
+    expect(screen.getByText(/Lv\.3/)).toBeInTheDocument();
+    expect(screen.getByText(/Lv\.4/)).toBeInTheDocument();
+  });
+
+  it('shows reward description when provided', () => {
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription="Watch a movie"
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/ご褒美/)).toBeInTheDocument();
+    expect(screen.getByText('Watch a movie')).toBeInTheDocument();
+  });
+
+  it('does not show reward section when rewardDescription is null', () => {
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByText(/ご褒美/)).not.toBeInTheDocument();
+  });
+
+  it('shows multi-level transition (e.g. 3 → 5)', () => {
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={5}
+        rewardDescription={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Lv\.3/)).toBeInTheDocument();
+    expect(screen.getByText(/Lv\.5/)).toBeInTheDocument();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription={null}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses role="dialog" for accessibility', () => {
+    render(
+      <LevelUpDialog
+        open
+        previousLevel={3}
+        newLevel={4}
+        rewardDescription={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/src/ui/pages/CalendarPage.tsx
+++ b/src/ui/pages/CalendarPage.tsx
@@ -5,16 +5,19 @@
  * Uses useCalendarData hook for data management and useRepositories for data access.
  */
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRepositories } from '@/hooks/useRepositories';
 import { useCalendarData } from '@/hooks/useCalendarData';
 import { useStatsData } from '@/hooks/useStatsData';
+import { useLevelUpDetection } from '@/hooks/useLevelUpDetection';
 import { HeatmapCalendar } from '@/ui/components/HeatmapCalendar';
 import { HabitFilter } from '@/ui/components/HabitFilter';
 import { LevelBar } from '@/ui/components/LevelBar';
 import { WeeklyMonthlyStats } from '@/ui/components/WeeklyMonthlyStats';
+import { LevelUpDialog } from '@/ui/components/LevelUpDialog';
 import { Button } from '@/components/ui/button';
+import type { Reward } from '@/domain/models';
 
 // --- Sub-components ---
 
@@ -90,7 +93,8 @@ function MonthNavigationHeader({
 // --- Main Page ---
 
 export function CalendarPage() {
-  const { habitRepository, completionRepository } = useRepositories();
+  const { habitRepository, completionRepository, rewardRepository } =
+    useRepositories();
 
   const {
     year,
@@ -108,6 +112,32 @@ export function CalendarPage() {
   } = useCalendarData(habitRepository, completionRepository);
 
   const stats = useStatsData(habitRepository, completionRepository);
+  const levelUp = useLevelUpDetection(stats.xp?.level ?? null);
+
+  // Load rewards once so we can look up the reward for the new level
+  const [rewards, setRewards] = useState<readonly Reward[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    void rewardRepository
+      .findAll()
+      .then((data) => {
+        if (!cancelled) setRewards(data);
+      })
+      .catch(() => {
+        // Silently ignore — the dialog just won't show a reward
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [rewardRepository]);
+
+  const rewardForNewLevel = useMemo(() => {
+    if (levelUp.event === null) return null;
+    return (
+      rewards.find((r) => r.level === levelUp.event!.newLevel)?.description ??
+      null
+    );
+  }, [levelUp.event, rewards]);
 
   const selectedHabitColor = useMemo(() => {
     if (filter.mode !== 'habit') return undefined;
@@ -174,6 +204,14 @@ export function CalendarPage() {
           onFilterChange={setFilter}
         />
       </div>
+
+      <LevelUpDialog
+        open={levelUp.event !== null}
+        previousLevel={levelUp.event?.previousLevel ?? 0}
+        newLevel={levelUp.event?.newLevel ?? 0}
+        rewardDescription={rewardForNewLevel}
+        onClose={levelUp.dismiss}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要

XP・レベルシステム Phase 6。レベルアップを localStorage で検知し、タイミングよくダイアログを表示する。ご褒美が登録済みなら一緒に表示する。

closes #133

## 変更内容

### 新規ファイル
- \`src/ui/components/LevelUpDialog.tsx\`: モーダル UI（タイトル / レベル遷移 / ご褒美 / 閉じるボタン）
- \`src/hooks/useLevelUpDetection.ts\`: localStorage キー \`daily-rituals-last-level\` で検知
  - 初回起動: ダイアログ非表示、現在レベルを保存
  - 同レベル: 何もしない
  - レベルアップ: \`{previousLevel, newLevel}\` イベントを発行
  - 複数レベルアップ: 最終レベルのみ表示
  - 防御: 下降時は localStorage を現在に同期
  - 無効値（NaN等）: 初回として扱う
  - dismiss(): localStorage を更新してダイアログを閉じる

### 統合
- \`src/ui/pages/CalendarPage.tsx\`:
  - \`useLevelUpDetection(stats.xp?.level ?? null)\`
  - \`rewardRepository.findAll()\` で取得した ご褒美一覧から該当レベルを検索
  - \`<LevelUpDialog>\` を末尾にマウント

## 受け入れ基準

- [x] LevelUpDialog コンポーネント作成
- [x] タイトル「レベルアップ！」
- [x] レベル遷移 \`Lv.X → Lv.Y\`
- [x] ご褒美表示（設定済みのみ）
- [x] 閉じるボタン
- [x] localStorage キー \`daily-rituals-last-level\`
- [x] 初回起動でダイアログ非表示
- [x] 複数レベルアップは最終レベルのみ
- [x] CalendarPage 統合

## テスト

- 新規ユニット 15 ケース（dialog 7, hook 8）
- 全ユニット: 675 → 690 全パス
- typecheck: PASS
- E2E: 44 全パス（リグレッション確認）

## 注記

- マルチデバイスで localStorage は共有されない（個人利用のため許容）
- ご褒美データ取得失敗時はダイアログのご褒美セクションが非表示になるだけ
- Phase 7 (E2E) が後続