### PR TITLE
fix: アプリ起動時にプッシュ購読を自動再登録

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,26 @@ jobs:
             echo "SUPABASE_LOCAL_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"
           } >> "$GITHUB_ENV"
 
+      # Newer Supabase local stacks may not auto-grant public-table privileges
+      # to the API roles, causing "permission denied for table ..." during E2E
+      # seeding. Re-assert the grants explicitly. Local stack only — production
+      # is managed by Supabase and unaffected (this never touches migrations).
+      - name: Grant privileges on public tables to Supabase roles (local stack)
+        run: |
+          eval "$(supabase status -o env)"
+          : "${DB_URL:?supabase status did not return DB_URL}"
+          echo "== grants on public.habits BEFORE =="
+          psql "$DB_URL" -Atc "select grantee||':'||privilege_type from information_schema.role_table_grants where table_schema='public' and table_name='habits' order by 1;" || true
+          psql "$DB_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+          GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+          GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+          SQL
+          echo "== grants on public.habits AFTER =="
+          psql "$DB_URL" -Atc "select grantee||':'||privilege_type from information_schema.role_table_grants where table_schema='public' and table_name='habits' order by 1;" || true
+
       - name: Run E2E tests
         run: npm run test:e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Start Supabase
         run: supabase start
 
+      - name: Export Supabase local credentials for E2E
+        run: |
+          eval "$(supabase status -o env)"
+          : "${API_URL:?supabase status did not return API_URL}"
+          : "${ANON_KEY:?supabase status did not return ANON_KEY}"
+          : "${SERVICE_ROLE_KEY:?supabase status did not return SERVICE_ROLE_KEY}"
+          {
+            echo "SUPABASE_LOCAL_URL=$API_URL"
+            echo "SUPABASE_LOCAL_ANON_KEY=$ANON_KEY"
+            echo "SUPABASE_LOCAL_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"
+          } >> "$GITHUB_ENV"
+
       - name: Run E2E tests
         run: npm run test:e2e
 

--- a/docs/investigations/2026-07-02-push-notification-not-delivered.md
+++ b/docs/investigations/2026-07-02-push-notification-not-delivered.md
@@ -1,0 +1,102 @@
+# プッシュ通知が届かない問題 — 調査結果と対処手順
+
+- **調査日**: 2026-07-02（2026-07-03 に DB 実データで最終確定）
+- **対象**: プッシュ通知リマインダー（habits の `reminder_time` による通知）
+- **症状**: リマインダー時刻になっても iPhone に通知が届かない
+- **結論（DB 実データで確定）**: **`push_subscriptions` テーブルが空＝通知の宛先（デバイス購読）が存在しない。** そのため送信関数は常に `sent:0` になり、通知が届かない。最後に送信成功した日付は 2026-04-21（`last_notified_date`）。それ以降 iOS 側で購読が失効し、再登録されていない。
+- **確定の根拠**:
+  1. `push_subscriptions` を照会 → **0 行**。
+  2. リマインダー設定済みの習慣（日記・ソフトウェア開発, `13:00:00` UTC）の `last_notified_date` が `2026-04-21` で停止。この列は「送信成功時のみ」更新されるため、最後に通知が成功したのが 4/21 であることを示す。
+  3. `net._http_response` の直近実行は**全て HTTP 200**、内容は `No habits to notify` / `All habits completed`。関数は正常に動作しており、時刻判定・完了判定ロジックにバグは無い。
+- **インフラは全て正常だったことを確認済み**（当初仮説は棄却）: pg_cron ジョブ（jobid 3, `*/10 * * * *`, active）は登録済みで実行も全て succeeded。URL は `daily-rituals-nine.vercel.app/api/send-reminders`、認証は `x-cron-secret` で正しい。手動で本番エンドポイントを叩いても 200 `{"sent":0,"message":"No habits to notify"}` を返す。→ **原因は cron でも Vercel 関数でもなく、クライアント側の購読喪失。**
+- **自動復旧しない理由（設計上の穴）**: `usePushSubscription` のサイレント再登録は「ブラウザに購読が残るが DB に無い」場合のみ動作し、iOS のように購読ごと消えると `existingSub` が null で早期 return する。新規購読を作る `ensureSubscription` は習慣の作成/編集でリマインダー ON 保存時（`NewHabitPage` / `HabitDetailPage`）にしか呼ばれず、起動時・設定画面での再購読トリガーが無い。
+
+> 注: 2026-07-02 時点で `cron.job_run_details` を確認した際、`users`/`participants` の DELETE ジョブしか見えず「send-reminders 未登録」と誤判定した。これは**別の Supabase プロジェクトで SQL を実行していた**ためで、正しいプロジェクト（`rfobzbtkqhsqoyyuafuv`）では send-reminders は正常稼働していた。教訓: cron 診断は必ず対象プロジェクトで実行すること。
+
+---
+
+## 1. アーキテクチャ（現状の想定フロー）
+
+```
+pg_cron (10分ごと)
+  → pg_net (net.http_post)
+    → Vercel API Route  https://daily-rituals-nine.vercel.app/api/send-reminders
+       (認証: x-cron-secret ヘッダー)
+      → 未完了習慣を検索し web-push で送信
+        → Service Worker (src/sw.ts) が受信し通知表示
+```
+
+- 送信の実体: `api/send-reminders.ts`（Vercel Serverless / Node.js）
+- 認証: リクエストヘッダー `x-cron-secret` を環境変数 `CRON_SECRET` と照合。不一致・欠落は **401 Unauthorized**
+- 過去の経緯: 当初は Supabase Edge Function（Deno）だったが、`web-push` の Deno 非互換のため #73 で Vercel API Route に移行、#74 で Edge Function を削除
+
+---
+
+## 2. 根本原因（DB 実行履歴で確定）
+
+**`send-reminders` の pg_cron ジョブが実行されていない（未登録、または無効化されている）。** pg_cron ジョブは Supabase DB 内の手動設定で、リポジトリのマイグレーションには含まれない。#71 で当初設定されたものが、#73（Vercel 移行）/ #74（Edge Function 削除）の過程で登録し直されなかった、あるいは一度も正しく登録されていなかったと考えられる。
+
+`cron.job_run_details` の直近履歴には別アプリの日次 DELETE ジョブしか現れず、`send-reminders` の実行が 1 件も存在しないことから、ジョブが稼働していないと断定できる（10分間隔なら直近履歴を占有するはず）。
+
+### 補足: 当初仮説との差分（棄却された仮説）
+
+当初、下記2点を最有力原因と推定していたが、実データにより「ジョブがそもそも動いていない」ことが判明したため、これらは**現時点では該当しない**（ただしジョブを新規登録する際に同じ誤りを繰り返さないよう、正しい URL / 認証は手順②で担保する）。
+
+- ~~**呼び出し先 URL が古い**: 旧 `<SUPABASE_URL>/functions/v1/send-reminders`（#74 で削除済み）を叩き続けている~~
+- ~~**認証方式が古い**: 旧 `Authorization: Bearer <SERVICE_ROLE_KEY>` のまま（移行後の関数は `x-cron-secret` のみ検証し 401）~~
+
+---
+
+## 3. 根拠（DB 実データ・エンドポイント検証）
+
+| # | 確認内容 | 結果 |
+|---|----------|------|
+| 1 | **`push_subscriptions` の中身** | **0 行**。通知の宛先が存在しない。→ 送信関数は宛先ゼロで `sent:0` を返し、通知は届きようがない |
+| 2 | **`habits` のリマインダー設定** | 日記・ソフトウェア開発（`13:00:00` UTC, daily）と朝起きる（`22:10:00` UTC, weekly_days）にリマインダーあり。前者の `last_notified_date` は **`2026-04-21`** で停止。この列は送信成功時のみ更新されるため、最後の成功が 4/21 だと分かる |
+| 3 | **`net._http_response`（cron の実 HTTP 応答）** | 直近すべて **HTTP 200**。内容は `No habits to notify`（UTC 0時台は 13:00/22:10 の習慣がまだ時刻前）/ `All habits completed`（前夜は完了済み）。関数は正常動作、時刻・完了判定にバグなし |
+| 4 | **手動エンドポイント呼び出し** | 正しい `x-cron-secret` で `POST` → **200 `{"sent":0,"message":"No habits to notify"}`**。関数まで完全到達し正常応答 |
+| 5 | **pg_cron ジョブ** | jobid 3 / `*/10 * * * *` / `active: true` / URL `daily-rituals-nine.vercel.app/api/send-reminders` / `x-cron-secret`。`cron.job_run_details` は全て succeeded。**設定・稼働ともに正常** |
+
+結論: **インフラ（cron → pg_net → Vercel → 関数 → 認証）は全て健全。唯一の欠落はクライアント側のデバイス購読**（`push_subscriptions` が空）。
+
+---
+
+## 4. 自動復旧しない理由（コードの設計上の穴）
+
+- `usePushSubscription.ts` の**サイレント再登録**は、`registration.pushManager.getSubscription()` が購読を返す（＝ブラウザ側に購読が残っている）場合のみ DB へ再登録する。iOS のように**購読ごと失効**すると `existingSub` が `null` になり `return` して何もしない。
+- **新規購読を作る `ensureSubscription()`** は、習慣の作成/編集画面で**リマインダー ON にして保存したとき**にしか呼ばれない（`NewHabitPage.tsx`, `HabitDetailPage.tsx:99-101`）。アプリ起動時・設定画面に再購読トリガーが無い。
+- ⇒ 一度デバイス購読が消えると、ユーザーが手動で習慣のリマインダーを付け直すまで復活しない。
+
+---
+
+## 5. あなたが対処すべき手順（iPhone 実機での再購読）
+
+1. **ホーム画面に追加した PWA** を開く（Safari のタブ不可。iOS の Web Push はホーム画面 PWA でのみ有効）。
+2. 既存の習慣（例:「日記」）を開く。
+3. **リマインダーのトグルを OFF にして保存 → もう一度 ON にして時刻を選び保存**。通知許可を聞かれたら「許可」。これで `ensureSubscription()` が走り、`push_subscriptions` に新しい行が登録される。
+4. 過去に通知を「拒否」していた場合は、iOS 設定 → 該当 PWA → 通知 で許可し直してから再度手順3を行う。
+
+### 検証
+
+- 再購読後、`push_subscriptions` に行が増えたことを確認（`SELECT count(*) FROM push_subscriptions;`）。
+- 習慣のリマインダー時刻を直近（未完了状態）に設定し、次の 10 分境界で iPhone に通知が届くか確認。急ぐ場合は本番エンドポイントを手動 POST して `sent:1` になるか確認できる。
+
+---
+
+## 6. 恒久対策（コード改修の提案 / 任意）
+
+- **アプリ起動時の無条件再購読**: サイレント再登録を「ブラウザ購読が無ければ新規 subscribe して DB 登録する」ロジックに拡張すれば、iOS の購読失効から自動復旧できる（通知許可が `granted` の間）。今回の再発の根治策。→ 別 issue/PR を推奨。
+- **設定画面に通知の再登録 UI を追加**: 習慣編集に依存せず購読を貼り直せる導線があると復旧が容易。
+- （参考）調査初期に作成した `supabase/snippets/setup-cron.sql` と設計書の cron SQL 修正は、原因ではなかったが**運用ドキュメントとして有効**なので残置。将来デプロイ URL 変更時などに参照可能。
+
+---
+
+## 付録: 参照
+
+- 送信処理: `api/send-reminders.ts`
+- Service Worker: `src/sw.ts`
+- 購読フック: `src/hooks/usePushSubscription.ts`
+- 時刻変換: `src/lib/reminderTime.ts`
+- 設計書: `docs/superpowers/specs/2026-03-21-push-reminder-design.md`
+- cron 設定 SQL: `supabase/snippets/setup-cron.sql`
+- 関連 Issue/PR: #71（機能追加）, #73（Vercel 移行）, #74（Edge Function 削除）

--- a/docs/superpowers/specs/2026-03-21-push-reminder-design.md
+++ b/docs/superpowers/specs/2026-03-21-push-reminder-design.md
@@ -88,16 +88,21 @@ CREATE POLICY "Users can manage own subscriptions"
   USING (auth.uid() = user_id)
   WITH CHECK (auth.uid() = user_id);
 
--- pg_cronジョブの設定（10分ごとにEdge Functionを呼び出し）
+-- pg_cronジョブの設定（10分ごとにVercel API Routeを呼び出し）
+-- 注意: #73 で送信処理を Vercel API Route (Node.js) に移行し、
+--       #74 で Edge Function を削除済み。呼び出し先とヘッダーが以下に変わっている:
+--   - url: <VERCEL_APP_URL>/api/send-reminders （旧: <SUPABASE_URL>/functions/v1/send-reminders）
+--   - 認証: x-cron-secret ヘッダー （旧: Authorization: Bearer <SERVICE_ROLE_KEY>）
+-- 実際に適用する SQL は supabase/snippets/setup-cron.sql を参照。
 SELECT cron.schedule(
   'send-reminders',
   '*/10 * * * *',
   $$
   SELECT net.http_post(
-    url := '<SUPABASE_URL>/functions/v1/send-reminders',
+    url := 'https://<VERCEL_APP_URL>/api/send-reminders',
     headers := jsonb_build_object(
-      'Authorization', 'Bearer <SUPABASE_SERVICE_ROLE_KEY>',
-      'Content-Type', 'application/json'
+      'Content-Type', 'application/json',
+      'x-cron-secret', '<CRON_SECRET>'
     ),
     body := '{}'::jsonb
   );

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const SUPABASE_LOCAL_URL = 'http://127.0.0.1:54321';
+// Local Supabase credentials. In CI these are injected from the running stack
+// via `supabase status -o env` (see .github/workflows/e2e.yml) so they stay in
+// sync with whatever Supabase CLI version is used. The hardcoded values are the
+// legacy `supabase start` defaults, kept only as a fallback for local runs.
+const SUPABASE_LOCAL_URL =
+  process.env.SUPABASE_LOCAL_URL ?? 'http://127.0.0.1:54321';
 const SUPABASE_LOCAL_ANON_KEY =
+  process.env.SUPABASE_LOCAL_ANON_KEY ??
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
 
 export const SUPABASE_LOCAL_SERVICE_ROLE_KEY =
+  process.env.SUPABASE_LOCAL_SERVICE_ROLE_KEY ??
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
 
 export { SUPABASE_LOCAL_URL, SUPABASE_LOCAL_ANON_KEY };

--- a/src/hooks/__tests__/pushSubscriptionOperations.test.ts
+++ b/src/hooks/__tests__/pushSubscriptionOperations.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PushSubscriptionRepository } from '../../data/repositories/pushSubscriptionRepository';
+import {
+  reconcileSubscription,
+  ensureSubscription,
+} from '../pushSubscriptionOperations';
+
+// A valid base64url VAPID public key (atob-able after transform).
+const VAPID_KEY =
+  'BIQHildiu8tu7dTwTm4GVMTyuxsxInrAGulnynO04w-BfL1SGRPOo89jIt6sx4O2ODy2R04nXU3LhtxlkJemSF8';
+
+type MockSub = {
+  endpoint: string;
+  toJSON: () => { keys: { p256dh: string; auth: string } };
+  unsubscribe: ReturnType<typeof vi.fn>;
+};
+
+const makeSub = (endpoint: string, p256dh = 'p256', auth = 'auth'): MockSub => ({
+  endpoint,
+  toJSON: () => ({ keys: { p256dh, auth } }),
+  unsubscribe: vi.fn().mockResolvedValue(true),
+});
+
+const makeRegistration = (opts: {
+  existing?: MockSub | null;
+  newSub?: MockSub;
+}) => {
+  const subscribe = vi.fn().mockResolvedValue(opts.newSub ?? makeSub('new-endpoint'));
+  const getSubscription = vi.fn().mockResolvedValue(opts.existing ?? null);
+  return {
+    pushManager: { getSubscription, subscribe },
+  } as unknown as ServiceWorkerRegistration & {
+    pushManager: { getSubscription: typeof getSubscription; subscribe: typeof subscribe };
+  };
+};
+
+const makeRepository = (
+  overrides: Partial<PushSubscriptionRepository> = {},
+): PushSubscriptionRepository => ({
+  upsert: vi.fn().mockResolvedValue(undefined),
+  findByEndpoint: vi.fn().mockResolvedValue(null),
+  deleteByEndpoint: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.stubEnv('VITE_VAPID_PUBLIC_KEY', VAPID_KEY);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('reconcileSubscription', () => {
+  it('does nothing when an existing browser subscription is already tracked in the DB', async () => {
+    const existing = makeSub('tracked-endpoint');
+    const registration = makeRegistration({ existing });
+    const repository = makeRepository({
+      findByEndpoint: vi.fn().mockResolvedValue({ endpoint: 'tracked-endpoint' }),
+    });
+
+    await reconcileSubscription(registration, repository, 'granted');
+
+    expect(existing.unsubscribe).not.toHaveBeenCalled();
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the subscription when the browser sub is not tracked in the DB', async () => {
+    const existing = makeSub('stale-endpoint');
+    const newSub = makeSub('fresh-endpoint', 'p-new', 'a-new');
+    const registration = makeRegistration({ existing, newSub });
+    const repository = makeRepository({
+      findByEndpoint: vi.fn().mockResolvedValue(null),
+    });
+
+    await reconcileSubscription(registration, repository, 'granted');
+
+    expect(existing.unsubscribe).toHaveBeenCalledOnce();
+    expect(registration.pushManager.subscribe).toHaveBeenCalledOnce();
+    expect(repository.upsert).toHaveBeenCalledWith({
+      endpoint: 'fresh-endpoint',
+      p256dh: 'p-new',
+      auth: 'a-new',
+    });
+  });
+
+  it('auto re-subscribes when there is no browser sub but permission is granted', async () => {
+    const newSub = makeSub('created-endpoint', 'p-c', 'a-c');
+    const registration = makeRegistration({ existing: null, newSub });
+    const repository = makeRepository();
+
+    await reconcileSubscription(registration, repository, 'granted');
+
+    expect(registration.pushManager.subscribe).toHaveBeenCalledOnce();
+    expect(repository.upsert).toHaveBeenCalledWith({
+      endpoint: 'created-endpoint',
+      p256dh: 'p-c',
+      auth: 'a-c',
+    });
+  });
+
+  it('does NOT subscribe when there is no browser sub and permission is default', async () => {
+    const registration = makeRegistration({ existing: null });
+    const repository = makeRepository();
+
+    await reconcileSubscription(registration, repository, 'default');
+
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT subscribe when there is no browser sub and permission is denied', async () => {
+    const registration = makeRegistration({ existing: null });
+    const repository = makeRepository();
+
+    await reconcileSubscription(registration, repository, 'denied');
+
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureSubscription', () => {
+  it('subscribes and persists when no subscription exists', async () => {
+    const newSub = makeSub('ensure-endpoint', 'p-e', 'a-e');
+    const registration = makeRegistration({ existing: null, newSub });
+    const repository = makeRepository();
+
+    await ensureSubscription(registration, repository);
+
+    expect(registration.pushManager.subscribe).toHaveBeenCalledOnce();
+    expect(repository.upsert).toHaveBeenCalledWith({
+      endpoint: 'ensure-endpoint',
+      p256dh: 'p-e',
+      auth: 'a-e',
+    });
+  });
+
+  it('persists the existing subscription without re-subscribing', async () => {
+    const existing = makeSub('existing-endpoint', 'p-x', 'a-x');
+    const registration = makeRegistration({ existing });
+    const repository = makeRepository();
+
+    await ensureSubscription(registration, repository);
+
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+    expect(repository.upsert).toHaveBeenCalledWith({
+      endpoint: 'existing-endpoint',
+      p256dh: 'p-x',
+      auth: 'a-x',
+    });
+  });
+});

--- a/src/hooks/__tests__/usePushSubscription.test.tsx
+++ b/src/hooks/__tests__/usePushSubscription.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * usePushSubscription tests - Focuses on the regression this hook must not
+ * reintroduce: it must NOT call usePushSubscriptionReconcile itself.
+ * Reconciliation runs exactly once, at the app root, via AppLayout (see
+ * AppLayout.test.tsx). If this hook also reconciled, a page using it
+ * (NewHabitPage/HabitDetailPage) landed on directly would mount alongside
+ * AppLayout and run reconcileSubscription twice concurrently against the
+ * same repository.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { PushSubscriptionRepository } from '../../data/repositories/pushSubscriptionRepository';
+import { usePushSubscription } from '../usePushSubscription';
+
+const mockReconcile = vi.fn();
+vi.mock('../usePushSubscriptionReconcile', () => ({
+  usePushSubscriptionReconcile: (repository: PushSubscriptionRepository | null) =>
+    mockReconcile(repository),
+}));
+
+const makeRepository = (): PushSubscriptionRepository => ({
+  upsert: vi.fn().mockResolvedValue(undefined),
+  findByEndpoint: vi.fn().mockResolvedValue(null),
+  deleteByEndpoint: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('usePushSubscription', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not reconcile the push subscription itself (AppLayout owns that)', () => {
+    const repository = makeRepository();
+
+    renderHook(() => usePushSubscription(repository));
+
+    expect(mockReconcile).not.toHaveBeenCalled();
+  });
+
+  it('returns the current notification permission state', () => {
+    const repository = makeRepository();
+
+    const { result } = renderHook(() => usePushSubscription(repository));
+
+    expect(result.current.permissionState).toBe(
+      typeof Notification !== 'undefined' ? Notification.permission : 'default',
+    );
+  });
+});

--- a/src/hooks/__tests__/usePushSubscriptionReconcile.test.tsx
+++ b/src/hooks/__tests__/usePushSubscriptionReconcile.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * usePushSubscriptionReconcile tests - Verifies the hook wires up
+ * reconcileSubscription on mount (service worker readiness, permission
+ * lookup, and the "never prompt on load" guarantee). Branch-level behavior
+ * of reconcileSubscription itself is covered by pushSubscriptionOperations.test.ts;
+ * these tests focus on whether the hook actually invokes it when mounted.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { PushSubscriptionRepository } from '../../data/repositories/pushSubscriptionRepository';
+import { usePushSubscriptionReconcile } from '../usePushSubscriptionReconcile';
+
+const VAPID_KEY =
+  'BIQHildiu8tu7dTwTm4GVMTyuxsxInrAGulnynO04w-BfL1SGRPOo89jIt6sx4O2ODy2R04nXU3LhtxlkJemSF8';
+
+const makeRepository = (
+  overrides: Partial<PushSubscriptionRepository> = {},
+): PushSubscriptionRepository => ({
+  upsert: vi.fn().mockResolvedValue(undefined),
+  findByEndpoint: vi.fn().mockResolvedValue(null),
+  deleteByEndpoint: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeRegistration = (opts: {
+  existingSub?: { endpoint: string } | null;
+  rejectGetSubscription?: boolean;
+}) => {
+  const getSubscription = opts.rejectGetSubscription
+    ? vi.fn().mockRejectedValue(new Error('boom'))
+    : vi.fn().mockResolvedValue(opts.existingSub ?? null);
+  const subscribe = vi.fn().mockResolvedValue({
+    endpoint: 'new-endpoint',
+    toJSON: () => ({ keys: { p256dh: 'p', auth: 'a' } }),
+  });
+  return { pushManager: { getSubscription, subscribe } } as unknown as ServiceWorkerRegistration & {
+    pushManager: { getSubscription: typeof getSubscription; subscribe: typeof subscribe };
+  };
+};
+
+beforeEach(() => {
+  vi.stubEnv('VITE_VAPID_PUBLIC_KEY', VAPID_KEY);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('usePushSubscriptionReconcile', () => {
+  it('auto re-subscribes on mount when permission is already granted and no browser sub exists', async () => {
+    const registration = makeRegistration({ existingSub: null });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { ready: Promise.resolve(registration) },
+    });
+    vi.stubGlobal('Notification', { permission: 'granted' });
+    const repository = makeRepository();
+
+    renderHook(() => usePushSubscriptionReconcile(repository));
+
+    await waitFor(() => {
+      expect(registration.pushManager.subscribe).toHaveBeenCalledOnce();
+    });
+    expect(repository.upsert).toHaveBeenCalledWith({
+      endpoint: 'new-endpoint',
+      p256dh: 'p',
+      auth: 'a',
+    });
+  });
+
+  it('never prompts (does not subscribe) on mount when permission is not granted', async () => {
+    const registration = makeRegistration({ existingSub: null });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { ready: Promise.resolve(registration) },
+    });
+    vi.stubGlobal('Notification', { permission: 'default' });
+    const repository = makeRepository();
+
+    renderHook(() => usePushSubscriptionReconcile(repository));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no repository', async () => {
+    const registration = makeRegistration({ existingSub: null });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { ready: Promise.resolve(registration) },
+    });
+    vi.stubGlobal('Notification', { permission: 'granted' });
+
+    renderHook(() => usePushSubscriptionReconcile(null));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(registration.pushManager.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the browser has no serviceWorker support', async () => {
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('Notification', { permission: 'granted' });
+    const repository = makeRepository();
+
+    renderHook(() => usePushSubscriptionReconcile(repository));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(repository.upsert).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from the reconcile process (best-effort)', async () => {
+    const registration = makeRegistration({ rejectGetSubscription: true });
+    vi.stubGlobal('navigator', {
+      serviceWorker: { ready: Promise.resolve(registration) },
+    });
+    vi.stubGlobal('Notification', { permission: 'granted' });
+    const repository = makeRepository();
+
+    expect(() =>
+      renderHook(() => usePushSubscriptionReconcile(repository)),
+    ).not.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});

--- a/src/hooks/pushSubscriptionOperations.ts
+++ b/src/hooks/pushSubscriptionOperations.ts
@@ -1,0 +1,114 @@
+import type { PushSubscriptionRepository } from '../data/repositories/pushSubscriptionRepository';
+
+/**
+ * Reads the VAPID public key from the environment.
+ * @throws when VITE_VAPID_PUBLIC_KEY is not configured.
+ */
+export function getVapidPublicKey(): string {
+  const key = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+  if (!key) {
+    throw new Error('VITE_VAPID_PUBLIC_KEY is not configured');
+  }
+  return key;
+}
+
+/**
+ * Converts a base64url-encoded VAPID key into the Uint8Array the
+ * Push API expects for `applicationServerKey`.
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; i++) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+/**
+ * Persists a browser PushSubscription to the repository.
+ */
+async function persistSubscription(
+  subscription: PushSubscription,
+  repository: PushSubscriptionRepository,
+): Promise<void> {
+  const keys = subscription.toJSON().keys ?? {};
+  await repository.upsert({
+    endpoint: subscription.endpoint,
+    p256dh: keys.p256dh ?? '',
+    auth: keys.auth ?? '',
+  });
+}
+
+/**
+ * Creates a fresh push subscription and persists it to the repository.
+ */
+async function subscribeAndSave(
+  registration: ServiceWorkerRegistration,
+  repository: PushSubscriptionRepository,
+): Promise<void> {
+  const vapidKey = urlBase64ToUint8Array(getVapidPublicKey());
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: vapidKey,
+  });
+  await persistSubscription(subscription, repository);
+}
+
+/**
+ * Reconciles the device's push subscription on app load (best-effort).
+ *
+ * - Browser subscription exists and is tracked in the DB: nothing to do.
+ * - Browser subscription exists but is missing from the DB: refresh it
+ *   (unsubscribe + subscribe + persist).
+ * - No browser subscription but permission is already `granted`: create a
+ *   new one. This recovers from iOS silently dropping the subscription,
+ *   which otherwise required the user to manually re-enable a reminder.
+ * - No browser subscription and permission is not granted: do nothing
+ *   (never prompt for permission on load).
+ */
+export async function reconcileSubscription(
+  registration: ServiceWorkerRegistration,
+  repository: PushSubscriptionRepository,
+  permission: NotificationPermission,
+): Promise<void> {
+  const existingSub = await registration.pushManager.getSubscription();
+
+  if (existingSub) {
+    const dbSub = await repository.findByEndpoint(existingSub.endpoint);
+    if (dbSub) {
+      return;
+    }
+    await existingSub.unsubscribe();
+    await subscribeAndSave(registration, repository);
+    return;
+  }
+
+  if (permission === 'granted') {
+    await subscribeAndSave(registration, repository);
+  }
+}
+
+/**
+ * Ensures a push subscription exists and is persisted. Called from an
+ * explicit user action (enabling a habit reminder), so it may create a
+ * subscription (which can trigger the permission prompt).
+ */
+export async function ensureSubscription(
+  registration: ServiceWorkerRegistration,
+  repository: PushSubscriptionRepository,
+): Promise<void> {
+  let subscription = await registration.pushManager.getSubscription();
+
+  if (!subscription) {
+    const vapidKey = urlBase64ToUint8Array(getVapidPublicKey());
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: vapidKey,
+    });
+  }
+
+  await persistSubscription(subscription, repository);
+}

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { PushSubscriptionRepository } from '../data/repositories/pushSubscriptionRepository';
+import {
+  reconcileSubscription,
+  ensureSubscription as ensureSubscriptionOp,
+} from './pushSubscriptionOperations';
 
 export type UsePushSubscriptionReturn = {
   readonly permissionState: NotificationPermission;
@@ -7,23 +11,8 @@ export type UsePushSubscriptionReturn = {
   readonly ensureSubscription: () => Promise<void>;
 };
 
-function getVapidPublicKey(): string {
-  const key = import.meta.env.VITE_VAPID_PUBLIC_KEY;
-  if (!key) {
-    throw new Error('VITE_VAPID_PUBLIC_KEY is not configured');
-  }
-  return key;
-}
-
-function urlBase64ToUint8Array(base64String: string): Uint8Array {
-  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
-  const rawData = atob(base64);
-  const outputArray = new Uint8Array(rawData.length);
-  for (let i = 0; i < rawData.length; i++) {
-    outputArray[i] = rawData.charCodeAt(i);
-  }
-  return outputArray;
+function hasServiceWorker(): boolean {
+  return typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
 }
 
 export function usePushSubscription(
@@ -39,38 +28,24 @@ export function usePushSubscription(
     }
   }, []);
 
-  // Silent re-registration on app load
+  // Reconcile the device subscription on app load (best-effort). This also
+  // re-subscribes when iOS has silently dropped the subscription, as long as
+  // notification permission is already granted.
   useEffect(() => {
-    if (!repository || typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+    if (!repository || !hasServiceWorker()) return;
 
-    async function checkAndReregister() {
+    async function reconcile() {
       try {
         const registration = await navigator.serviceWorker.ready;
-        const existingSub = await registration.pushManager.getSubscription();
-        if (!existingSub) return;
-
-        const dbSub = await repository!.findByEndpoint(existingSub.endpoint);
-        if (dbSub) return;
-
-        await existingSub.unsubscribe();
-        const vapidKey = urlBase64ToUint8Array(getVapidPublicKey());
-        const newSub = await registration.pushManager.subscribe({
-          userVisibleOnly: true,
-          applicationServerKey: vapidKey,
-        });
-
-        const keys = newSub.toJSON().keys ?? {};
-        await repository!.upsert({
-          endpoint: newSub.endpoint,
-          p256dh: keys.p256dh ?? '',
-          auth: keys.auth ?? '',
-        });
+        const permission =
+          typeof Notification !== 'undefined' ? Notification.permission : 'default';
+        await reconcileSubscription(registration, repository!, permission);
       } catch {
-        // Silent failure — re-registration is best-effort
+        // Silent failure — reconciliation is best-effort.
       }
     }
 
-    void checkAndReregister();
+    void reconcile();
   }, [repository]);
 
   const requestPermission = useCallback(async (): Promise<boolean> => {
@@ -81,25 +56,9 @@ export function usePushSubscription(
   }, []);
 
   const ensureSubscription = useCallback(async (): Promise<void> => {
-    if (!repository || typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
-
+    if (!repository || !hasServiceWorker()) return;
     const registration = await navigator.serviceWorker.ready;
-    let subscription = await registration.pushManager.getSubscription();
-
-    if (!subscription) {
-      const vapidKey = urlBase64ToUint8Array(getVapidPublicKey());
-      subscription = await registration.pushManager.subscribe({
-        userVisibleOnly: true,
-        applicationServerKey: vapidKey,
-      });
-    }
-
-    const keys = subscription.toJSON().keys ?? {};
-    await repository.upsert({
-      endpoint: subscription.endpoint,
-      p256dh: keys.p256dh ?? '',
-      auth: keys.auth ?? '',
-    });
+    await ensureSubscriptionOp(registration, repository);
   }, [repository]);
 
   return { permissionState, requestPermission, ensureSubscription };

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,19 +1,14 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { PushSubscriptionRepository } from '../data/repositories/pushSubscriptionRepository';
-import {
-  reconcileSubscription,
-  ensureSubscription as ensureSubscriptionOp,
-} from './pushSubscriptionOperations';
+import { ensureSubscription as ensureSubscriptionOp } from './pushSubscriptionOperations';
+import { usePushSubscriptionReconcile } from './usePushSubscriptionReconcile';
+import { hasServiceWorker } from './utils';
 
 export type UsePushSubscriptionReturn = {
   readonly permissionState: NotificationPermission;
   readonly requestPermission: () => Promise<boolean>;
   readonly ensureSubscription: () => Promise<void>;
 };
-
-function hasServiceWorker(): boolean {
-  return typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
-}
 
 export function usePushSubscription(
   repository: PushSubscriptionRepository | null,
@@ -28,25 +23,10 @@ export function usePushSubscription(
     }
   }, []);
 
-  // Reconcile the device subscription on app load (best-effort). This also
-  // re-subscribes when iOS has silently dropped the subscription, as long as
-  // notification permission is already granted.
-  useEffect(() => {
-    if (!repository || !hasServiceWorker()) return;
-
-    async function reconcile() {
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        const permission =
-          typeof Notification !== 'undefined' ? Notification.permission : 'default';
-        await reconcileSubscription(registration, repository!, permission);
-      } catch {
-        // Silent failure — reconciliation is best-effort.
-      }
-    }
-
-    void reconcile();
-  }, [repository]);
+  // Reconcile the device subscription on mount (best-effort). Also mounted
+  // unconditionally at the app root (AppLayout) so it runs even when this
+  // hook itself isn't — see usePushSubscriptionReconcile for details.
+  usePushSubscriptionReconcile(repository);
 
   const requestPermission = useCallback(async (): Promise<boolean> => {
     if (typeof Notification === 'undefined') return false;

--- a/src/hooks/usePushSubscription.ts
+++ b/src/hooks/usePushSubscription.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { PushSubscriptionRepository } from '../data/repositories/pushSubscriptionRepository';
 import { ensureSubscription as ensureSubscriptionOp } from './pushSubscriptionOperations';
-import { usePushSubscriptionReconcile } from './usePushSubscriptionReconcile';
 import { hasServiceWorker } from './utils';
 
 export type UsePushSubscriptionReturn = {
@@ -10,6 +9,18 @@ export type UsePushSubscriptionReturn = {
   readonly ensureSubscription: () => Promise<void>;
 };
 
+/**
+ * Manages notification permission state and exposes an explicit
+ * `ensureSubscription` for user-initiated subscribe actions (e.g. enabling a
+ * habit reminder).
+ *
+ * This hook does NOT reconcile the push subscription itself — that runs
+ * once at the app root via `usePushSubscriptionReconcile` in `AppLayout`,
+ * which wraps every authenticated route. Calling it again here would race
+ * with the AppLayout instance when a page using this hook is the initial
+ * landing route (e.g. a deep link to `/habits/:id`), since both would mount
+ * together and reconcile the same repository concurrently.
+ */
 export function usePushSubscription(
   repository: PushSubscriptionRepository | null,
 ): UsePushSubscriptionReturn {
@@ -22,11 +33,6 @@ export function usePushSubscription(
       setPermissionState(Notification.permission);
     }
   }, []);
-
-  // Reconcile the device subscription on mount (best-effort). Also mounted
-  // unconditionally at the app root (AppLayout) so it runs even when this
-  // hook itself isn't — see usePushSubscriptionReconcile for details.
-  usePushSubscriptionReconcile(repository);
 
   const requestPermission = useCallback(async (): Promise<boolean> => {
     if (typeof Notification === 'undefined') return false;

--- a/src/hooks/usePushSubscriptionReconcile.ts
+++ b/src/hooks/usePushSubscriptionReconcile.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import type { PushSubscriptionRepository } from '../data/repositories/pushSubscriptionRepository';
+import { reconcileSubscription } from './pushSubscriptionOperations';
+import { hasServiceWorker } from './utils';
+
+/**
+ * Reconciles the device's push subscription once per mount (best-effort).
+ *
+ * This also re-subscribes when iOS has silently dropped the subscription,
+ * as long as notification permission is already granted. It never prompts
+ * for permission on load — see `reconcileSubscription` for the exact rules.
+ *
+ * Mount this once near the app root (e.g. AppLayout, which wraps every
+ * authenticated route) so it runs on every session regardless of which
+ * page the user lands on first. Do not gate it behind a specific page.
+ */
+export function usePushSubscriptionReconcile(
+  repository: PushSubscriptionRepository | null,
+): void {
+  useEffect(() => {
+    if (!repository || !hasServiceWorker()) return;
+
+    async function reconcile() {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const permission =
+          typeof Notification !== 'undefined' ? Notification.permission : 'default';
+        await reconcileSubscription(registration, repository!, permission);
+      } catch {
+        // Silent failure — reconciliation is best-effort.
+      }
+    }
+
+    void reconcile();
+  }, [repository]);
+}

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -22,3 +22,10 @@ export function isRlsError(err: unknown): boolean {
   const code = (err as Record<string, unknown>).code;
   return code === RLS_VIOLATION_CODE;
 }
+
+/**
+ * Checks whether the current browser supports the Service Worker API.
+ */
+export function hasServiceWorker(): boolean {
+  return typeof navigator !== 'undefined' && 'serviceWorker' in navigator;
+}

--- a/src/ui/layouts/AppLayout.tsx
+++ b/src/ui/layouts/AppLayout.tsx
@@ -17,9 +17,18 @@ import {
   BottomNavigation,
 } from '@/ui/components/NavigationBar';
 import { useAuthContext } from '@/hooks/useAuthContext';
+import { useRepositories } from '@/hooks/useRepositories';
+import { usePushSubscriptionReconcile } from '@/hooks/usePushSubscriptionReconcile';
 
 export function AppLayout() {
   const { user } = useAuthContext();
+  const { pushSubscriptionRepository } = useRepositories();
+
+  // Reconcile the push subscription once per authenticated session,
+  // regardless of which route the user lands on first. AppLayout wraps
+  // every protected route, so this recovers from iOS silently dropping the
+  // subscription without requiring the user to visit a specific page.
+  usePushSubscriptionReconcile(pushSubscriptionRepository);
 
   if (!user) {
     return null;

--- a/src/ui/layouts/__tests__/AppLayout.test.tsx
+++ b/src/ui/layouts/__tests__/AppLayout.test.tsx
@@ -8,10 +8,11 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/vitest';
 import { AppLayout } from '../AppLayout';
+import type { PushSubscriptionRepository } from '@/data/repositories/pushSubscriptionRepository';
 
 // Mock useAuthContext to provide a test user
 vi.mock('@/hooks/useAuthContext', () => ({
@@ -26,6 +27,30 @@ vi.mock('@/hooks/useAuthContext', () => ({
     signIn: vi.fn(),
     signOut: vi.fn(),
   }),
+}));
+
+// Mock useRepositories - AppLayout reconciles the push subscription on
+// mount, which requires access to the pushSubscriptionRepository.
+const mockPushSubscriptionRepository: PushSubscriptionRepository = {
+  upsert: vi.fn().mockResolvedValue(undefined),
+  findByEndpoint: vi.fn().mockResolvedValue(null),
+  deleteByEndpoint: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('@/hooks/useRepositories', () => ({
+  useRepositories: () => ({
+    pushSubscriptionRepository: mockPushSubscriptionRepository,
+  }),
+}));
+
+// Mock usePushSubscriptionReconcile so navigation tests below don't touch
+// the real service worker / Notification APIs, and so the wiring test below
+// can assert AppLayout actually invokes it on mount.
+const mockReconcile = vi.fn();
+vi.mock('@/hooks/usePushSubscriptionReconcile', () => ({
+  usePushSubscriptionReconcile: (
+    repository: PushSubscriptionRepository | null,
+  ) => mockReconcile(repository),
 }));
 
 function renderWithRouter(initialRoute = '/') {
@@ -82,5 +107,33 @@ describe('AppLayout', () => {
     renderWithRouter();
     const main = screen.getByRole('main');
     expect(main).toBeInTheDocument();
+  });
+});
+
+describe('AppLayout push subscription reconciliation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression test for the case where usePushSubscription (and therefore
+  // reconcileSubscription) was only wired into NewHabitPage/HabitDetailPage,
+  // so a user landing on any other route (e.g. the default "/" Today page)
+  // never triggered a re-subscribe after iOS silently dropped the
+  // subscription. AppLayout wraps every authenticated route, so reconciling
+  // here guarantees it runs once per session regardless of the landing page.
+  it('reconciles the push subscription on mount, regardless of route', async () => {
+    renderWithRouter('/');
+
+    await waitFor(() => {
+      expect(mockReconcile).toHaveBeenCalledWith(mockPushSubscriptionRepository);
+    });
+  });
+
+  it('reconciles the push subscription even when landing on a non-default route', async () => {
+    renderWithRouter('/calendar');
+
+    await waitFor(() => {
+      expect(mockReconcile).toHaveBeenCalledWith(mockPushSubscriptionRepository);
+    });
   });
 });

--- a/supabase/snippets/setup-cron.sql
+++ b/supabase/snippets/setup-cron.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- send-reminders: pg_cron ジョブ設定（プッシュ通知リマインダー）
+-- ============================================================
+--
+-- このジョブは 10 分ごとに Vercel API Route を呼び出し、
+-- 該当時刻のリマインダーを持つ未完了習慣に通知を送信する。
+--
+-- 重要（#73 / #74 の移行後の正しい設定）:
+--   - 呼び出し先は Supabase Edge Function ではなく Vercel API Route。
+--     Edge Function（/functions/v1/send-reminders）は削除済み（commit bc8d6b4）。
+--   - 認証は `Authorization: Bearer <SERVICE_ROLE_KEY>` ではなく
+--     `x-cron-secret: <CRON_SECRET>` ヘッダーを使う。
+--     （api/send-reminders.ts は x-cron-secret のみを検証し、
+--      それ以外は 401 Unauthorized を返す）
+--
+-- 実行前に置き換える値:
+--   <VERCEL_APP_URL> : 本番デプロイの URL（例: daily-rituals-nine.vercel.app）
+--   <CRON_SECRET>    : Vercel 環境変数 CRON_SECRET と同一の値
+--
+-- 前提: pg_cron と pg_net 拡張が有効であること。
+--   CREATE EXTENSION IF NOT EXISTS pg_cron;
+--   CREATE EXTENSION IF NOT EXISTS pg_net;
+-- ------------------------------------------------------------
+
+-- 旧ジョブ（Edge Function 宛て / Bearer 認証）が残っていれば削除する。
+-- 存在しない場合のエラーを無視するため DO ブロックで囲む。
+DO $$
+BEGIN
+  PERFORM cron.unschedule('send-reminders');
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END $$;
+
+-- Vercel API Route 宛て / x-cron-secret 認証で再登録する。
+SELECT cron.schedule(
+  'send-reminders',
+  '*/10 * * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://<VERCEL_APP_URL>/api/send-reminders',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', '<CRON_SECRET>'
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- ------------------------------------------------------------
+-- 診断用クエリ（トラブルシューティング時に実行）
+-- ------------------------------------------------------------
+-- 登録済みジョブの確認（url / headers が Vercel + x-cron-secret になっているか）:
+--   SELECT jobid, schedule, active, command FROM cron.job WHERE jobname = 'send-reminders';
+--
+-- 直近の実行結果の確認（status = 'succeeded' か、HTTP 応答は何か）:
+--   SELECT jobid, status, return_message, start_time, end_time
+--   FROM cron.job_run_details
+--   ORDER BY start_time DESC
+--   LIMIT 20;
+--
+-- pg_net の HTTP 応答本文の確認（200 / 401 / 404 など）:
+--   SELECT id, status_code, content, error_msg, created
+--   FROM net._http_response
+--   ORDER BY created DESC
+--   LIMIT 20;


### PR DESCRIPTION
## 背景 / 根本原因（通知不達）

「プッシュ通知が届かない」を調査した結果、根本原因は **`push_subscriptions` テーブルが空＝iPhoneのデバイス購読が失効し、再登録されていなかった** ことでした（cron・Vercel関数・認証はすべて正常稼働を確認済み。最後の通知成功は 2026-04-21）。

従来の `usePushSubscription` のサイレント再登録は「ブラウザに購読が残るが DB に無い」場合しか動かず、iOSのように購読ごと消えると `existingSub === null` で早期returnして何もしないため、ユーザーが習慣のリマインダーを手動で付け直すまで復旧しませんでした。

詳細は `docs/investigations/2026-07-02-push-notification-not-delivered.md`。

## 変更内容

### 1. プッシュ購読の自動再登録（本命の修正）
- 購読ロジックを `src/hooks/pushSubscriptionOperations.ts` に抽出（Manager/Operations分離パターン）
- `reconcileSubscription`: **ブラウザ購読が無くても通知許可が `granted` なら新規購読を作成**しDBへ再登録。iOSの購読失効から自動復旧。許可が `granted` 以外なら何もしない（起動時に権限プロンプトを出さない）
- `usePushSubscription.ts` を薄いラッパーにリファクタしロジック重複を解消
- ユニットテスト7ケース追加

### 2. E2E CI の修復（調査中に判明した別の pre-existing 破綻）
E2E が2026-04以来3ヶ月ぶりの実行で失敗。原因は本PRと無関係の環境ドリフト:
- **キーのハードコード + `version: latest`**: `playwright.config.ts` を環境変数優先に変更し、CIで `supabase status -o env` から実キーを注入（CLIバージョン非依存化）
- **新ローカルスタックがpublicテーブルにGRANTを自動付与しない**（診断で `habits` のGRANTが空だったことを確認）: `supabase start` 後に anon/authenticated/service_role へ明示的にGRANT（ローカル限定・マイグレーション非改変・本番影響なし）

## テスト

- ✅ ユニットテスト 682件（新規7件含む）
- ✅ typecheck
- ✅ **E2E CI グリーン**（GRANT前後の診断で権限空→付与を確認）
- ✅ DA レビュー APPROVE（コード変更。CRITICAL/HIGH なし）
- ⚠️ lint: リポジトリ全体で `eslint.config.js` 欠如（ESLint 9 未対応）により pre-existing で失敗。本変更と無関係。別issue推奨

## マージ後の確認（必須）

iPhone実機で、通知許可 `granted` の状態でアプリを起動 → `push_subscriptions` に行が復活することを確認（メモリの実機確認ルール）。

## Test plan
- [x] CI unit-test / e2e グリーン
- [ ] iPhone実機で購読が再登録され、リマインダー通知が届く