### PR TITLE
test: RewardsPageのフレーキーテストを解消（モック参照の安定化）

### DIFF
--- a/src/ui/pages/__tests__/RewardsPage.test.tsx
+++ b/src/ui/pages/__tests__/RewardsPage.test.tsx
@@ -17,20 +17,38 @@ import { DuplicateRewardLevelError } from '@/data/repositories/rewardRepository'
 import type { Reward } from '@/domain/models';
 
 // --- Mock repository ---
-
-const mockFindAll = vi.fn();
-const mockCreate = vi.fn();
-const mockUpdate = vi.fn();
-const mockRemove = vi.fn();
+//
+// The rewardRepository object identity must stay stable across renders.
+// RewardsPage's data-fetch useEffect depends on [rewardRepository], so if
+// this mock returned a fresh object literal on every call, the effect would
+// re-run on every render (setting isLoading -> unmounting RewardItem ->
+// losing its isEditing state), causing intermittent test failures. Using
+// vi.hoisted keeps a single shared object across the whole test file while
+// still allowing vi.clearAllMocks()/mockResolvedValue() in beforeEach to work
+// as before.
+const { mockFindAll, mockCreate, mockUpdate, mockRemove, mockRewardRepository } =
+  vi.hoisted(() => {
+    const mockFindAll = vi.fn();
+    const mockCreate = vi.fn();
+    const mockUpdate = vi.fn();
+    const mockRemove = vi.fn();
+    return {
+      mockFindAll,
+      mockCreate,
+      mockUpdate,
+      mockRemove,
+      mockRewardRepository: {
+        findAll: mockFindAll,
+        create: mockCreate,
+        update: mockUpdate,
+        remove: mockRemove,
+      },
+    };
+  });
 
 vi.mock('@/hooks/useRepositories', () => ({
   useRepositories: () => ({
-    rewardRepository: {
-      findAll: mockFindAll,
-      create: mockCreate,
-      update: mockUpdate,
-      remove: mockRemove,
-    },
+    rewardRepository: mockRewardRepository,
   }),
 }));
 


### PR DESCRIPTION
## 概要

`RewardsPage.test.tsx > cancels an edit without calling update` が約10回に1回の頻度で失敗するフレークを解消します。PR #142 の CI（`unit-test`）が実際にこれで落ちたため、先に単独で入れます。

## 症状

```
TestingLibraryElementError: Unable to find an element with the display value: Watch a movie.
```

失敗時の DOM を採取したところ、対象の `<li data-testid="reward-item">` は存在し中身も `Watch a movie` で正しいものの、**編集モードになっていません**（`<input>` ではなく `<span>` のまま）。編集ボタンのクリックで立った `isEditing` がアサーション時点で失われている状態でした。

## 原因

テストの `useRepositories` モックが、呼ばれるたびに新しい `rewardRepository` オブジェクトリテラルを返していました。

`RewardsPage.tsx:256` は `const { rewardRepository } = useRepositories()` で内側のオブジェクトを取り出し、`RewardsPage.tsx:262-286` の `useEffect` が `[rewardRepository]` に依存しています。参照が毎レンダー変わるため effect がレンダーのたびに再実行され、冒頭の `setIsLoading(true)` で `RewardItem` が一瞬アンマウントされます。アンマウントで `isEditing` が失われ、再フェッチ完了後に初期状態で再マウントされる——クリックとこのループの噛み合わせ次第で落ちるのでフレークになっていました。

**本番コードのバグではありません。** `RepositoryProvider`（`src/hooks/useRepositories.tsx`）は `useMemo` で値を安定させているため、実アプリでは参照が安定しています。欠陥はテストのモック側だけです。そのため本 PR はテストファイルのみを変更しています。

## 修正

`vi.hoisted` で `rewardRepository` を単一の共有オブジェクトにし、テストファイル実行中は参照が変わらないようにしました。`vi.clearAllMocks()` と `mockResolvedValue()` は従来どおり機能します。

なぜ `vi.hoisted` かというと、`vi.mock` のファクトリは巻き上げられるため、モジュールトップレベルの `const` を直接参照すると TDZ エラーになるためです。

## 検証

- 修正前（`origin/main`）: 10回実行して1回失敗を再現
- 修正後: **50回連続実行で 50/50 成功**（失敗率10%と仮定すると偶然50連続で通る確率は約0.5%）
- `npm test`: 52ファイル / 675テスト パス
- `tsc --noEmit`: クリーン

## 調査したが今回は変更しない箇所

同じ `vi.mock('@/hooks/useRepositories')` の形が `TodayPage.test.tsx` と `AppLayout.test.tsx` にもありますが、これらは内側のリポジトリ参照がモジュールレベル変数（`let mockHabitRepository` 等）で安定しており、消費側も `const { habitRepository } = useRepositories()` と個別参照に分解するため実害がありません。無用な変更を避けるため触っていません。
