### PR TITLE
refactor: 日付・時刻の判定を timeService に集約し、api を型チェック対象に加える

### DIFF
--- a/api/__tests__/send-reminders.test.ts
+++ b/api/__tests__/send-reminders.test.ts
@@ -3,6 +3,7 @@ import {
   buildNotificationBody,
   isWeeklyCountMet,
   isScheduledToday,
+  getUtcTimeSlot,
   type HabitRow,
 } from '../send-reminders';
 
@@ -142,5 +143,19 @@ describe('isScheduledToday', () => {
       frequency_value: null,
     };
     expect(isScheduledToday(habit, 1)).toBe(false);
+  });
+});
+
+describe('getUtcTimeSlot', () => {
+  it('returns the slot unchanged when already on a boundary', () => {
+    expect(getUtcTimeSlot(new Date('2026-08-13T09:10:00Z'))).toBe('09:10');
+  });
+
+  it('floors mid-slot minutes down to the slot boundary', () => {
+    expect(getUtcTimeSlot(new Date('2026-08-13T09:14:59Z'))).toBe('09:10');
+  });
+
+  it('handles the end-of-day 23:5x slot without rolling over the hour', () => {
+    expect(getUtcTimeSlot(new Date('2026-08-13T23:59:59Z'))).toBe('23:50');
   });
 });

--- a/api/send-reminders.ts
+++ b/api/send-reminders.ts
@@ -9,7 +9,7 @@
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import webpush from 'web-push';
 
 // --- Constants ---
@@ -144,7 +144,7 @@ type SendResult = {
 async function sendNotificationsPerUser(
   habitsByUser: ReadonlyMap<string, readonly string[]>,
   incompleteHabits: readonly HabitRow[],
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
 ): Promise<SendResult> {
   let totalSent = 0;
   let notifiedHabitIds: readonly string[] = [];

--- a/api/send-reminders.ts
+++ b/api/send-reminders.ts
@@ -11,6 +11,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import webpush from 'web-push';
+import { getLocalTime, floorToSlot } from '../src/domain/services/timeService';
 
 // --- Constants ---
 
@@ -42,13 +43,12 @@ function getTodayUtc(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+export function getUtcTimeSlot(instant: Date): string {
+  return floorToSlot(getLocalTime(instant, 'UTC'), NOTIFICATION_WINDOW_MINUTES);
+}
+
 function getCurrentUtcTimeSlot(): string {
-  const now = new Date();
-  const hours = now.getUTCHours();
-  const minutes =
-    Math.floor(now.getUTCMinutes() / NOTIFICATION_WINDOW_MINUTES) *
-    NOTIFICATION_WINDOW_MINUTES;
-  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+  return getUtcTimeSlot(new Date());
 }
 
 function getWeekStartUtc(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
+        "@types/web-push": "^3.6.4",
         "@typescript-eslint/eslint-plugin": "^8.33.1",
         "@typescript-eslint/parser": "^8.33.1",
         "@vercel/node": "^5.6.18",
@@ -4551,6 +4552,16 @@
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "license": "MIT"
+    },
+    "node_modules/@types/web-push": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/web-push/-/web-push-3.6.4.tgz",
+      "integrity": "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/web-push": "^3.6.4",
     "@typescript-eslint/eslint-plugin": "^8.33.1",
     "@typescript-eslint/parser": "^8.33.1",
     "@vercel/node": "^5.6.18",

--- a/src/domain/services/__tests__/timeService.test.ts
+++ b/src/domain/services/__tests__/timeService.test.ts
@@ -3,7 +3,7 @@ import {
   getLocalDate,
   getLocalTime,
   getLocalDayOfWeek,
-  getWeekStart,
+  getWeekStartSunday,
   addDays,
   floorToSlot,
   isValidTimeZone,
@@ -60,14 +60,14 @@ describe('getLocalDayOfWeek', () => {
   });
 });
 
-describe('getWeekStart', () => {
+describe('getWeekStartSunday', () => {
   it('日曜始まりの週開始日を返す', () => {
     // 2026-03-12 は木曜。直前の日曜は 03-08
-    expect(getWeekStart(new Date('2026-03-12T03:00:00Z'), TOKYO)).toBe('2026-03-08');
+    expect(getWeekStartSunday(new Date('2026-03-12T03:00:00Z'), TOKYO)).toBe('2026-03-08');
   });
 
   it('日曜当日はその日を返す', () => {
-    expect(getWeekStart(new Date('2026-03-08T03:00:00Z'), TOKYO)).toBe('2026-03-08');
+    expect(getWeekStartSunday(new Date('2026-03-08T03:00:00Z'), TOKYO)).toBe('2026-03-08');
   });
 });
 
@@ -84,8 +84,7 @@ describe('addDays', () => {
     expect(addDays('2028-02-28', 1)).toBe('2028-02-29');
   });
 
-  it('DST のある地域でも日付がずれない', () => {
-    // 2026-03-08 はニューヨークの DST 開始日。ローカル時刻ベースの実装だと壊れる
+  it('連続する日付を通常どおり 1 日ずつ進める', () => {
     expect(addDays('2026-03-07', 1)).toBe('2026-03-08');
     expect(addDays('2026-03-08', 1)).toBe('2026-03-09');
   });

--- a/src/domain/services/__tests__/timeService.test.ts
+++ b/src/domain/services/__tests__/timeService.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getLocalDate,
+  getLocalTime,
+  getLocalDayOfWeek,
+  getWeekStart,
+  addDays,
+  floorToSlot,
+  isValidTimeZone,
+} from '../timeService';
+
+const TOKYO = 'Asia/Tokyo';
+const NEW_YORK = 'America/New_York';
+const KIRITIMATI = 'Pacific/Kiritimati'; // UTC+14
+
+describe('getLocalDate', () => {
+  it('UTC 22:00 は東京では翌日', () => {
+    expect(getLocalDate(new Date('2026-03-11T22:00:00Z'), TOKYO)).toBe('2026-03-12');
+  });
+
+  it('UTC 02:00 はニューヨークでは前日', () => {
+    expect(getLocalDate(new Date('2026-03-12T02:00:00Z'), NEW_YORK)).toBe('2026-03-11');
+  });
+
+  it('UTC+14 では UTC より 1 日進む', () => {
+    expect(getLocalDate(new Date('2026-03-11T12:00:00Z'), KIRITIMATI)).toBe('2026-03-12');
+  });
+});
+
+describe('getLocalTime', () => {
+  it('東京は UTC+9', () => {
+    expect(getLocalTime(new Date('2026-03-11T22:00:00Z'), TOKYO)).toBe('07:00');
+  });
+
+  it('真夜中を 24:00 ではなく 00:00 として返す', () => {
+    expect(getLocalTime(new Date('2026-03-11T15:00:00Z'), TOKYO)).toBe('00:00');
+  });
+
+  it('DST 開始後のニューヨークは UTC-4', () => {
+    // 2026-03-08 に夏時間開始
+    expect(getLocalTime(new Date('2026-03-12T12:00:00Z'), NEW_YORK)).toBe('08:00');
+  });
+
+  it('DST 終了後のニューヨークは UTC-5', () => {
+    // 2026-11-01 に夏時間終了
+    expect(getLocalTime(new Date('2026-11-05T12:00:00Z'), NEW_YORK)).toBe('07:00');
+  });
+});
+
+describe('getLocalDayOfWeek', () => {
+  it('2026-03-12 は木曜（4）', () => {
+    expect(getLocalDayOfWeek(new Date('2026-03-12T03:00:00Z'), TOKYO)).toBe(4);
+  });
+
+  it('日付をまたぐと曜日も変わる', () => {
+    // UTC 2026-03-11T22:00 は東京では 03-12 木曜
+    expect(getLocalDayOfWeek(new Date('2026-03-11T22:00:00Z'), TOKYO)).toBe(4);
+    // UTC 2026-03-11T12:00 は東京では 03-11 水曜
+    expect(getLocalDayOfWeek(new Date('2026-03-11T12:00:00Z'), TOKYO)).toBe(3);
+  });
+});
+
+describe('getWeekStart', () => {
+  it('日曜始まりの週開始日を返す', () => {
+    // 2026-03-12 は木曜。直前の日曜は 03-08
+    expect(getWeekStart(new Date('2026-03-12T03:00:00Z'), TOKYO)).toBe('2026-03-08');
+  });
+
+  it('日曜当日はその日を返す', () => {
+    expect(getWeekStart(new Date('2026-03-08T03:00:00Z'), TOKYO)).toBe('2026-03-08');
+  });
+});
+
+describe('addDays', () => {
+  it('月をまたぐ', () => {
+    expect(addDays('2026-03-31', 1)).toBe('2026-04-01');
+  });
+
+  it('負の日数で戻る', () => {
+    expect(addDays('2026-03-01', -1)).toBe('2026-02-28');
+  });
+
+  it('うるう年を扱う', () => {
+    expect(addDays('2028-02-28', 1)).toBe('2028-02-29');
+  });
+
+  it('DST のある地域でも日付がずれない', () => {
+    // 2026-03-08 はニューヨークの DST 開始日。ローカル時刻ベースの実装だと壊れる
+    expect(addDays('2026-03-07', 1)).toBe('2026-03-08');
+    expect(addDays('2026-03-08', 1)).toBe('2026-03-09');
+  });
+});
+
+describe('floorToSlot', () => {
+  it('10 分単位に切り捨てる', () => {
+    expect(floorToSlot('07:23', 10)).toBe('07:20');
+    expect(floorToSlot('07:00', 10)).toBe('07:00');
+    expect(floorToSlot('23:59', 10)).toBe('23:50');
+  });
+});
+
+describe('isValidTimeZone', () => {
+  it('正しい IANA 名を受け入れる', () => {
+    expect(isValidTimeZone(TOKYO)).toBe(true);
+  });
+
+  it('不正な名前を拒否する', () => {
+    expect(isValidTimeZone('Not/AZone')).toBe(false);
+  });
+});

--- a/src/domain/services/calendarService.ts
+++ b/src/domain/services/calendarService.ts
@@ -4,6 +4,7 @@ import {
   isActiveOnDate,
   isCountedAsTargetOnDate,
 } from './habitScheduleService';
+import { addDays } from './timeService';
 
 const DAYS_IN_WEEK = 7;
 const WEEKS_IN_GRID = 6;
@@ -95,12 +96,6 @@ export type DayAchievement = {
   readonly completedHabitNames: readonly string[];
   readonly isTargetDay: boolean;
 };
-
-export function addDays(dateStr: string, days: number): string {
-  const d = new Date(dateStr + 'T00:00:00');
-  d.setDate(d.getDate() + days);
-  return `${d.getFullYear()}-${padTwo(d.getMonth() + 1)}-${padTwo(d.getDate())}`;
-}
 
 export function calculateDailyAchievements(
   habits: readonly Habit[],

--- a/src/domain/services/statsService.ts
+++ b/src/domain/services/statsService.ts
@@ -6,7 +6,7 @@
  */
 
 import type { DayAchievement } from './calendarService';
-import { addDays } from './calendarService';
+import { addDays } from './timeService';
 
 export type DateRange = {
   readonly start: string;

--- a/src/domain/services/timeService.ts
+++ b/src/domain/services/timeService.ts
@@ -1,0 +1,124 @@
+/**
+ * timeService - タイムゾーンを明示的に受け取る日付・時刻の純粋関数群。
+ *
+ * このアプリにおける「今日」「今の時刻」の定義はすべてここに集約する。
+ * クライアント（src/）と Vercel API Route（api/）の双方がこのファイルだけを参照する。
+ *
+ * 実装は Intl.DateTimeFormat ベースであり、分オフセット（getTimezoneOffset）を
+ * 使わない。これにより DST が自動的に正しく扱われる。
+ */
+
+const DATE_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+const TIME_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
+
+const MINUTES_PER_HOUR = 60;
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function getDateFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = DATE_FORMATTERS.get(timeZone);
+  if (cached) return cached;
+
+  // en-CA は YYYY-MM-DD 形式を返す
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  DATE_FORMATTERS.set(timeZone, formatter);
+  return formatter;
+}
+
+function getTimeFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = TIME_FORMATTERS.get(timeZone);
+  if (cached) return cached;
+
+  // hourCycle: 'h23' により真夜中が 24:00 ではなく 00:00 になる
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  });
+  TIME_FORMATTERS.set(timeZone, formatter);
+  return formatter;
+}
+
+/**
+ * 指定タイムゾーンにおけるその瞬間の日付を YYYY-MM-DD で返す。
+ */
+export function getLocalDate(instant: Date, timeZone: string): string {
+  return getDateFormatter(timeZone).format(instant);
+}
+
+/**
+ * 指定タイムゾーンにおけるその瞬間の時刻を HH:MM で返す。
+ */
+export function getLocalTime(instant: Date, timeZone: string): string {
+  const parts = getTimeFormatter(timeZone).formatToParts(instant);
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '00';
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '00';
+  return `${hour}:${minute}`;
+}
+
+/**
+ * 日付文字列に日数を加算する。
+ *
+ * UTC 上で計算するため、DST のある地域でも 1 日が 23 時間や 25 時間になる
+ * 影響を受けない。
+ */
+export function addDays(date: string, days: number): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * 指定タイムゾーンにおけるその瞬間の曜日を返す（0=日曜）。
+ */
+export function getLocalDayOfWeek(instant: Date, timeZone: string): number {
+  return new Date(`${getLocalDate(instant, timeZone)}T00:00:00Z`).getUTCDay();
+}
+
+/**
+ * 指定タイムゾーンにおける、その瞬間が属する週の開始日（日曜）を返す。
+ *
+ * 日曜始まりはカレンダーグリッドおよび statsService.getWeekRange と揃えている。
+ */
+export function getWeekStart(instant: Date, timeZone: string): string {
+  const date = getLocalDate(instant, timeZone);
+  return addDays(date, -getLocalDayOfWeek(instant, timeZone));
+}
+
+/**
+ * 時刻を指定分単位に切り捨てる。
+ */
+export function floorToSlot(time: string, slotMinutes: number): string {
+  const [hours, minutes] = time.split(':').map(Number);
+  const floored = Math.floor(minutes / slotMinutes) * slotMinutes;
+  return `${pad(hours)}:${pad(floored)}`;
+}
+
+/**
+ * IANA タイムゾーン名として有効か。
+ */
+export function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 実行環境のタイムゾーンを IANA 名で返す。
+ */
+export function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+export { MINUTES_PER_HOUR };

--- a/src/domain/services/timeService.ts
+++ b/src/domain/services/timeService.ts
@@ -1,8 +1,13 @@
 /**
  * timeService - タイムゾーンを明示的に受け取る日付・時刻の純粋関数群。
  *
- * このアプリにおける「今日」「今の時刻」の定義はすべてここに集約する。
- * クライアント（src/）と Vercel API Route（api/）の双方がこのファイルだけを参照する。
+ * このアプリにおける「今日」「今の時刻」の定義をここに集約していくのが目標状態。
+ * ただし現時点ではまだ以下がこのモジュールの外にあり、集約は完了していない：
+ * - api/send-reminders.ts の getTodayUtc()（Phase 3 で吸収予定）
+ * - src/hooks/useCalendarData.ts の年/月ベースのローカル日付取得（別形状のため未着手・移行時期未定）
+ * - src/lib/reminderTime.ts の getBrowserTimezoneOffset()（Phase 3 で吸収予定）
+ *
+ * クライアント（src/）と Vercel API Route（api/）の双方がこのファイルを参照する。
  *
  * 実装は Intl.DateTimeFormat ベースであり、分オフセット（getTimezoneOffset）を
  * 使わない。これにより DST が自動的に正しく扱われる。
@@ -10,8 +15,6 @@
 
 const DATE_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
 const TIME_FORMATTERS = new Map<string, Intl.DateTimeFormat>();
-
-const MINUTES_PER_HOUR = 60;
 
 function pad(n: number): string {
   return String(n).padStart(2, '0');
@@ -86,9 +89,18 @@ export function getLocalDayOfWeek(instant: Date, timeZone: string): number {
 /**
  * 指定タイムゾーンにおける、その瞬間が属する週の開始日（日曜）を返す。
  *
- * 日曜始まりはカレンダーグリッドおよび statsService.getWeekRange と揃えている。
+ * 日曜始まりであり、これはカレンダーグリッドおよび statsService.getWeekRange と
+ * 揃えるための意図的な選択。ただしこのコードベースには週開始の定義が他に複数あり、
+ * それらはすべて月曜始まりで、名前だけでは規約の違いが分からない：
+ * - src/domain/services/streakService.ts の（モジュール非公開の）getWeekStart
+ * - src/hooks/streakOperations.ts の getWeekStartDate
+ * - api/send-reminders.ts の getWeekStartUtc（isWeeklyCountMet に渡される）
+ *
+ * Phase 3 で send-reminders.ts の getWeekStartUtc() をこの getWeekStartSunday(now, tz)
+ * に置き換える計画があるが、これは単純な差し替えではない。日曜始まりへの変更により
+ * weekly_count の集計ウィンドウが最大 1 日分ずれる、意図的な挙動変更になる。
  */
-export function getWeekStart(instant: Date, timeZone: string): string {
+export function getWeekStartSunday(instant: Date, timeZone: string): string {
   const date = getLocalDate(instant, timeZone);
   return addDays(date, -getLocalDayOfWeek(instant, timeZone));
 }
@@ -120,5 +132,3 @@ export function isValidTimeZone(timeZone: string): boolean {
 export function getBrowserTimeZone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
-
-export { MINUTES_PER_HOUR };

--- a/src/domain/services/timeService.ts
+++ b/src/domain/services/timeService.ts
@@ -9,6 +9,13 @@
  *
  * クライアント（src/）と Vercel API Route（api/）の双方がこのファイルを参照する。
  *
+ * ⚠️ このファイルに `@/` エイリアス経由の import や外部依存を追加しないこと。
+ * api/ からは相対パス（../src/domain/services/timeService）で import されており、
+ * Vercel の esbuild バンドルが解決できるのは、このファイルが依存ゼロの自己完結
+ * モジュールだからである。esbuild は tsconfig の paths を確実には解決しないため、
+ * エイリアス import を足すと「型チェックは通るのにデプロイ後に壊れる」状態になる。
+ * 検証済みなのは相対 import のみで、エイリアス経由の解決は未検証。
+ *
  * 実装は Intl.DateTimeFormat ベースであり、分オフセット（getTimezoneOffset）を
  * 使わない。これにより DST が自動的に正しく扱われる。
  */

--- a/src/domain/services/xpService.ts
+++ b/src/domain/services/xpService.ts
@@ -1,6 +1,6 @@
 import type { Habit } from '@/domain/models/habit';
 import type { Completion } from '@/domain/models/completion';
-import { addDays } from './calendarService';
+import { addDays } from './timeService';
 import { isActiveOnDate, isCountedAsTargetOnDate } from './habitScheduleService';
 
 // --- Types ---

--- a/src/hooks/useStatsData.ts
+++ b/src/hooks/useStatsData.ts
@@ -22,6 +22,7 @@ import {
   getMonthRange,
   type AchievementSummary,
 } from '@/domain/services/statsService';
+import { getTodayString } from '@/lib/dateUtils';
 
 export type StatsData = {
   readonly isLoading: boolean;
@@ -29,13 +30,6 @@ export type StatsData = {
   readonly xp: XpBreakdown | null;
   readonly weekly: AchievementSummary | null;
   readonly monthly: AchievementSummary | null;
-};
-
-const padTwo = (n: number): string => String(n).padStart(2, '0');
-
-const getTodayString = (): string => {
-  const now = new Date();
-  return `${now.getFullYear()}-${padTwo(now.getMonth() + 1)}-${padTwo(now.getDate())}`;
 };
 
 const getEarliestHabitDate = (habits: readonly Habit[]): string | null => {

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,17 +1,25 @@
 /**
  * Date utility functions for date parsing, validation, and formatting.
+ *
+ * 日付そのものの計算は timeService に委譲し、ここでは「ブラウザのタイムゾーンを
+ * 使う」というアプリ固有の判断と、表示用の整形だけを担う。
  */
+
+import {
+  getLocalDate,
+  getBrowserTimeZone,
+  addDays as addDaysToDate,
+} from '@/domain/services/timeService';
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const DAY_NAMES = ['日', '月', '火', '水', '木', '金', '土'] as const;
 
 /**
- * Get today's date as YYYY-MM-DD string.
+ * Get today's date as YYYY-MM-DD string, in the browser's timezone.
  */
 export function getTodayString(): string {
-  const now = new Date();
-  return formatToDateString(now);
+  return getLocalDate(new Date(), getBrowserTimeZone());
 }
 
 /**
@@ -63,9 +71,7 @@ export function formatDisplayDate(dateStr: string): string {
  * Add days to a date string and return a new YYYY-MM-DD string.
  */
 export function addDays(dateStr: string, days: number): string {
-  const date = new Date(`${dateStr}T00:00:00`);
-  date.setDate(date.getDate() + days);
-  return formatToDateString(date);
+  return addDaysToDate(dateStr, days);
 }
 
 /**
@@ -80,11 +86,4 @@ export function isToday(dateStr: string): boolean {
  */
 export function isFutureDate(dateStr: string): boolean {
   return dateStr > getTodayString();
-}
-
-function formatToDateString(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "api", "vite.config.ts"]
 }


### PR DESCRIPTION
## 概要

信頼性立て直しトラックの **Phase 2** です。日付・時刻の計算を `timeService` に集約し、`api/` を型チェック対象に加えます。

**`reminder_time` の意味は変えていません。** UTC 保存と分オフセット変換は現状のままです。それを変えるのは Phase 3 で、意味が変わる変更を1つの PR に閉じるために意図的に分けています。

## 背景

「今日とは何か」がリポジトリ内の複数箇所で別々の前提で実装されていました。

| 場所 | 「今日」の定義 |
|---|---|
| `src/lib/dateUtils.ts` | 端末ローカル日付 |
| `src/hooks/useStatsData.ts` | 端末ローカル日付（`getTodayString` を**再実装**） |
| `src/lib/reminderTime.ts` | ローカル ⇄ UTC を**分オフセット**で変換 |
| `api/send-reminders.ts` | UTC 日付 |

分オフセット（`Date.getTimezoneOffset()`）は DST を表現できないため、この方式では原理的に正しくなりません。`addDays` も `dateUtils` と `calendarService` に重複していました。

## 変更内容

### `timeService` の新設

`src/domain/services/timeService.ts`。`Intl.DateTimeFormat` ベースで、すべての関数がタイムゾーンを明示的に引数で受け取ります（`getBrowserTimeZone` のみ例外）。分オフセット計算は一切使いません。

```ts
getLocalDate(instant, timeZone)       // 'YYYY-MM-DD'
getLocalTime(instant, timeZone)       // 'HH:MM'（真夜中は 00:00、24:00 にならない）
getLocalDayOfWeek(instant, timeZone)  // 0 = 日曜
getWeekStart(instant, timeZone)       // 日曜始まり
addDays(date, days)                   // UTC アンカーの暦日演算
floorToSlot(time, slotMinutes)
isValidTimeZone(timeZone)
getBrowserTimeZone()
```

テストは DST 境界（US 2026年は 3/8 開始・11/1 終了）、UTC 日付をまたぐ `Asia/Tokyo` の早朝、UTC+14 の `Pacific/Kiritimati` を含みます。

### 重複の解消

- `dateUtils.getTodayString` / `addDays` を `timeService` へ委譲
- `calendarService.addDays` を削除し、`statsService` / `xpService` は `timeService` から直接 import
- `useStatsData` の `getTodayString` 再実装を削除

挙動は変わりません。既存テストが安全網として機能しており、期待値は1つも変更していません（`dateUtils.test.ts` の差分はゼロ）。

### `api/` を型チェック対象に追加

`tsconfig.json` の `include` が `["src", "vite.config.ts"]` で、**`api/` は一度も型チェックされていませんでした**。`npm run typecheck` も CI も見ていない状態です。本番でしか壊れない領域を放置していた点は、web-push の Deno 非互換で痛い目を見たのと同じ構図なので、Phase 3 でこのファイルを大きく書き換える前に網をかけます。

追加した結果、既存の型エラーが2件出ました。どちらも型のみの修正で実行時の挙動は変えていません。

1. `@types/web-push` が未導入 → devDependency として追加
2. `ReturnType<typeof createClient>` と実際の `createClient()` の戻り型が不一致 → `SupabaseClient` で注釈

### `api/` から `src/` への import を実コードで検証

`api/send-reminders.ts` の10分丸め処理（自前実装）を `timeService.floorToSlot` 経由に置き換えました。UTC 基準のままなので挙動は変わりません。

これは **Phase 3 の前提条件の検証**を兼ねています。Phase 3 はクライアントとサーバーが同じ純粋関数を共有する設計なので、`api/` から `src/` への相対 import が Vercel のビルドで解決できることを先に確定させる必要があります。捨てるための一時コードを入れるより、実際の使用に置き換える方が検証として素直だと判断しました。

**この PR のプレビューデプロイに対して `/api/send-reminders` を叩き、200 が返ることを確認してからマージします。**

## 検証

- `npm test`: 57ファイル / **718テスト** パス
- `npm run typecheck`: クリーン（`api/` を含む）
- `npm run test:e2e`: 57/57 パス

## 備考

`npm run lint` はリポジトリ全体で実行不能です（ESLint 9 が flat な `eslint.config.js` を要求するが `.eslintrc.json` のまま）。当初この PR に相乗りさせる想定でしたが、lint を有効にすると既存違反が大量に出て PR の主題から逸れる恐れがあるため、**別 PR に分けます**。
