### PR TITLE
fix: Service Worker で skipWaiting/clientsClaim を呼びデプロイ反映を早める

### DIFF
--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,9 +1,26 @@
 /// <reference lib="webworker" />
 
-import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { precacheAndRoute, createHandlerBoundToURL, cleanupOutdatedCaches } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
 
 declare const self: ServiceWorkerGlobalScope;
+
+// Activate a newly-installed Service Worker immediately instead of leaving it
+// in `waiting` until every tab/PWA instance in this scope is fully closed.
+// Without this, a deployed update never takes over on devices that are
+// rarely fully quit (e.g. an iOS home-screen PWA), so the device keeps
+// running stale precached code indefinitely after a deploy.
+// NOTE: this only changes what the *next* load gets. A page that is already
+// open keeps running its old JS until it navigates or reloads — that is a
+// known, accepted limitation (no update-prompt/auto-reload UI by design),
+// not a bug left to fix here.
+self.skipWaiting();
+
+// Drop precaches left behind by an older Workbox cache-naming scheme once
+// this worker activates. precacheAndRoute() below already prunes individual
+// stale entries from the *current* precache on every deploy, so this mainly
+// guards against orphaned caches from a future Workbox major-version bump.
+cleanupOutdatedCaches();
 
 // Workbox precaching (injected by vite-plugin-pwa)
 precacheAndRoute(self.__WB_MANIFEST);
@@ -14,6 +31,14 @@ const navigationRoute = new NavigationRoute(handler, {
   denylist: [/^\/api\//],
 });
 registerRoute(navigationRoute);
+
+// Take control of any already-open clients as soon as this worker activates,
+// instead of only on their next navigation. Paired with skipWaiting() above:
+// together they collapse the update propagation window from "wait for every
+// tab to fully close" down to "wait for the next page load."
+self.addEventListener('activate', (event: ExtendableEvent) => {
+  event.waitUntil(self.clients.claim());
+});
 
 // Push notification handler
 self.addEventListener('push', (event: PushEvent) => {


### PR DESCRIPTION
## 概要

issue #151 の修正です。Service Worker に `skipWaiting()` と `clientsClaim()` を追加し、デプロイが端末に反映されるまでの遅延を解消します。

Closes #151

## 背景 — 実際に本番で踏みました

`src/sw.ts` は `precacheAndRoute` でアセットをキャッシュしますが、新しい Service Worker は**そのスコープの全クライアントが閉じられるまで `waiting` のまま**で、その間ずっと旧バンドルが配信されます。`src/sw.ts` は `skipWaiting()` も `clientsClaim()` も呼んでいませんでした。

`vite.config.ts` は `registerType: 'autoUpdate'` ですが、`strategies: 'injectManifest'` の場合 **`skipWaiting` は自動注入されません**（`generateSW` 戦略なら入る）。手書きの `sw.ts` を使う以上、自分で書く必要があります。

Phase 3（PR #150）のデプロイ時に、この問題が実害として現れました。

| 層 | 状態 |
|---|---|
| Vercel の本番コード | 新（`getTimezoneOffset` 0件 / `resolvedOptions` 1件で確認） |
| DB の `reminder_time` | 新（変換済み） |
| iPhone の PWA | **旧バンドルを配信 → 誤った時刻を表示** |

サーバー側は全て正しいのに端末だけが古く、**ユーザーは「マイグレーションで壊れた」と判断しました。** 状況から見て自然な判断です。解消には完全終了と再起動を2回繰り返す必要がありました。

さらに悪いことに、このとき表示されていた誤った時刻を「直そう」として保存すると、旧コードの変換ロジックが働いて**復旧不能な値が DB に書き込まれる**経路がありました。表示のずれがデータ破損に化ける構造です。

## 変更内容

`src/sw.ts` のみ。

- `self.skipWaiting()` — 待機せず即座に有効化
- `activate` イベント内で `event.waitUntil(self.clients.claim())` — 有効化後、既存クライアントを新 SW の管理下に移す
- `cleanupOutdatedCaches()` — 下記参照

`workbox-core` は直接依存に無いため、ネイティブの `ServiceWorkerGlobalScope` のメソッドを使っています。依存は増やしていません。

### `cleanupOutdatedCaches()` について

追加していますが、**今日時点では実質 no-op** です。Workbox のソースを確認したところ、`precacheAndRoute()` が既に現行プリキャッシュ内の古いエントリを毎回削除するためです。将来 Workbox のキャッシュ命名規則が変わったときに孤児キャッシュを掃除する保険として入れています。現行 SW 自身のキャッシュを消せないことも実装上確認済みです。

## 意図的に入れていないもの

**更新検知の通知や自動リロードは入れていません。** その結果、次の制約が残ります。

**既に開いているページは、次の読み込みまで古い JavaScript で動き続けます。** この変更が新しくするのは「次に配信されるもの」であって、実行中のコードではありません。バグと誤解されないよう `src/sw.ts` のコメントにも明記しました。

## ⚠️ 検証状況 — 肝心の挙動は未検証です

**この変更は既存のテストスイートでは検証できません。** そのことを明示しておきます。

- Vitest は Service Worker を動かさない
- Playwright は Vite dev サーバー相手で、`vite.config.ts` の `devOptions.enabled: false` により **SW が登録されない**
- SW の更新サイクルは、ビルド済みアセットを HTTP 配信し、2回デプロイして初めて動く

**検証できたこと**

- `npm test` 62ファイル / 750テスト パス
- `npm run typecheck` クリーン
- `npm run test:e2e` 58/58 パス
- `npm run build` 成功。`dist/sw.js` に `skipWaiting` / `clients.claim` / `cleanupOutdatedCaches` が残存し、18エントリのプリキャッシュマニフェストも維持されていることを確認

**検証できていないこと**

実際のブラウザで更新が伝播する挙動そのもの。これは本番に2回デプロイして実機で確認するまで分かりません。

## マージ後の注意

**この PR をマージしても、次のデプロイではまだ手動の完全終了が必要です。**

いま端末に入っている SW は `skipWaiting` を持たない旧版です。旧 SW が支配している限り、新しい SW（この修正入り）はやはり待機します。つまり次のデプロイで**もう一度だけ**完全終了が必要で、**その次のデプロイから自動で反映される**ようになります。

## 残る限界

この修正はデプロイ反映までの窓を「数日〜無期限」から「次回読み込みまで」に縮めるものであって、ゼロにするものではありません。**データ形式の意味が変わる変更では、引き続きデプロイ順序の手順が必要です。**
